### PR TITLE
fix: Adding padding to the toast no longer updates main layout

### DIFF
--- a/SampleApp/ToastView.swift
+++ b/SampleApp/ToastView.swift
@@ -5,7 +5,6 @@ struct ToastView: View {
     @State var toastIsPresented: Bool = true
     @State var toastStyle: Warp.ToastStyle = .success
     @State var toastEdge: Warp.ToastEdge = .top
-    @State var horizontalPadding: Double = 0
 
     var body: some View {
         ScrollView(showsIndicators: false) {
@@ -80,23 +79,6 @@ struct ToastView: View {
 
                 Divider()
 
-                Text("Horizontal Padding on Toast")
-                    .font(.headline)
-
-                HStack {
-                    Text("0")
-                    Slider(value: $horizontalPadding, in: 0...64)
-                    Text("64")
-                }
-
-                Text("Current value: ")
-                +
-                Text(
-                    horizontalPadding,
-                    format: .number.rounded(rule: .down, increment: 1.0)
-                )
-
-
                 Spacer()
             }
         }
@@ -105,7 +87,6 @@ struct ToastView: View {
             style: toastStyle,
             title: "Here's a toast of type \(toastStyle.description) located at the \(toastEdge.description) edge",
             edge: toastEdge,
-            horizontalPadding: horizontalPadding,
             isPresented: $toastIsPresented
         )
     }

--- a/SampleApp/ToastView.swift
+++ b/SampleApp/ToastView.swift
@@ -5,6 +5,7 @@ struct ToastView: View {
     @State var toastIsPresented: Bool = true
     @State var toastStyle: Warp.ToastStyle = .success
     @State var toastEdge: Warp.ToastEdge = .top
+    @State var horizontalPadding: Double = 0
 
     var body: some View {
         ScrollView(showsIndicators: false) {
@@ -57,7 +58,7 @@ struct ToastView: View {
                 .cornerRadius(8)
 
                 Text("Toast Style")
-                    .font(.caption)
+                    .font(.headline)
                 Picker("Toast Style:", selection: $toastStyle) {
                     ForEach(Warp.ToastStyle.allCases, id: \.self) { currentStyle in
                         Text(currentStyle.description)
@@ -68,7 +69,8 @@ struct ToastView: View {
                 Divider()
 
                 Text("Toast Edge")
-                    .font(.caption)
+                    .font(.headline)
+
                 Picker("Toast Edge:", selection: $toastEdge) {
                     ForEach(Warp.ToastEdge.allCases, id: \.self) { currentEdge in
                         Text(currentEdge.description)
@@ -78,6 +80,23 @@ struct ToastView: View {
 
                 Divider()
 
+                Text("Horizontal Padding on Toast")
+                    .font(.headline)
+
+                HStack {
+                    Text("0")
+                    Slider(value: $horizontalPadding, in: 0...64)
+                    Text("64")
+                }
+
+                Text("Current value: ")
+                +
+                Text(
+                    horizontalPadding,
+                    format: .number.rounded(rule: .down, increment: 1.0)
+                )
+
+
                 Spacer()
             }
         }
@@ -86,6 +105,7 @@ struct ToastView: View {
             style: toastStyle,
             title: "Here's a toast of type \(toastStyle.description) located at the \(toastEdge.description) edge",
             edge: toastEdge,
+            horizontalPadding: horizontalPadding,
             isPresented: $toastIsPresented
         )
     }

--- a/Sources/Toast/ToastViewModifier.swift
+++ b/Sources/Toast/ToastViewModifier.swift
@@ -5,6 +5,7 @@ extension Warp {
         let style: Warp.ToastStyle
         let title: String
         let edge: ToastEdge
+        let horizontalPadding: Double
         @Binding var isPresented: Bool
 
         public func body(content: Content) -> some View {
@@ -13,7 +14,6 @@ extension Warp {
                     alignment: edge.asAlignment,
                     content: warpToastOverlay
                 )
-                .padding(.horizontal, 16)
                 .zIndex(1)
                 .animation(.default, value: isPresented)
         }
@@ -27,6 +27,7 @@ extension Warp {
                     toastEdge: edge,
                     isPresented: $isPresented
                 )
+                .padding(.horizontal, horizontalPadding)
             }
         }
 
@@ -38,6 +39,7 @@ public extension View {
         style: Warp.ToastStyle,
         title: String,
         edge: Warp.ToastEdge,
+        horizontalPadding: Double = 0,
         isPresented: Binding<Bool>
     ) -> some View {
         self.modifier(
@@ -45,6 +47,7 @@ public extension View {
                 style: style,
                 title: title,
                 edge: edge,
+                horizontalPadding: horizontalPadding,
                 isPresented: isPresented
             )
         )

--- a/Sources/Toast/ToastViewModifier.swift
+++ b/Sources/Toast/ToastViewModifier.swift
@@ -5,7 +5,7 @@ extension Warp {
         let style: Warp.ToastStyle
         let title: String
         let edge: ToastEdge
-        let horizontalPadding: Double
+        private let horizontalPadding: Double = 16
         @Binding var isPresented: Bool
 
         public func body(content: Content) -> some View {
@@ -39,7 +39,6 @@ public extension View {
         style: Warp.ToastStyle,
         title: String,
         edge: Warp.ToastEdge,
-        horizontalPadding: Double = 0,
         isPresented: Binding<Bool>
     ) -> some View {
         self.modifier(
@@ -47,7 +46,6 @@ public extension View {
                 style: style,
                 title: title,
                 edge: edge,
-                horizontalPadding: horizontalPadding,
                 isPresented: isPresented
             )
         )


### PR DESCRIPTION
## Problem
I discovered that by setting the `.padding(.horizontal, 16)` in our ViewBuilder we also added 16 px of padding to the main content 😬 yeah...probably not what we want.

## Fix
So I moved it to be a parameter that you can pass to the Toast itself and then we set it on _that_ view when we compose the toast. 

That is

instead of setting it here:

```
public func body(content: Content) -> some View {
   content
        .overlay(
            alignment: edge.asAlignment,
            content: warpToastOverlay
        )
        .padding(.horizontal, 16) // <---- here is no good
        .zIndex(1)
        .animation(.default, value: isPresented)
}
```

We set it here

```
@ViewBuilder
func warpToastOverlay() -> some View {
    if isPresented {
        Warp.Toast(
            style: style,
            title: title,
            toastEdge: edge,
            isPresented: $isPresented
        )
        .padding(.horizontal, horizontalPadding) // <---- here is good 👌 
    }
}
```

## Example View
I updated the `ToastView` so you can see how the `horizontalPadding` effects your view