### PR TITLE
Adding Spacing and Border

### DIFF
--- a/Sources/Border/Border.swift
+++ b/Sources/Border/Border.swift
@@ -1,0 +1,40 @@
+import CoreFoundation
+
+extension Warp {
+    public enum Border: CGFloat {
+        /// Border radius of 2 points.
+        case borderRadius25
+        /// Border radius of 4 points.
+        case borderRadius50
+        /// Border radius of 8 points.
+        case borderRadius100
+        /// Border radius of 16 points.
+        case borderRadius200
+
+        /// Border width of 1 points.
+        case borderWidth12
+        /// Border width of 2 points.
+        case borderWidth25
+        /// Border width of 4 points.
+        case borderWidth50
+
+        var description: CGFloat {
+            switch self {
+            case .borderRadius25:
+                return 2
+            case .borderRadius50:
+                return 4
+            case .borderRadius100:
+                return 8
+            case .borderRadius200:
+                return 16
+            case .borderWidth12:
+                return 1
+            case .borderWidth25:
+                return 2
+            case .borderWidth50:
+                return 4
+            }
+        }
+    }
+}

--- a/Sources/Spacing/Spacing.swift
+++ b/Sources/Spacing/Spacing.swift
@@ -1,0 +1,42 @@
+import CoreFoundation
+
+extension Warp {
+    public enum Spacing: CGFloat {
+        /// Separation of 2 points.
+        case spacing25 = 2
+        /// Separation of 4 points.
+        case spacing50 = 4
+        /// Separation of 8 points.
+        case spacing100 = 8
+        /// Separation of 12 points.
+        case spacing150 = 12
+        /// Separation of 16 points.
+        case spacing200 = 16
+        /// Separation of 20 points.
+        case spacing250 = 20
+        /// Separation of 24 points.
+        case spacing300 = 24
+        /// Separation of 32 points.
+        case spacing400 = 32
+        /// Separation of 40 points.
+        case spacing500 = 40
+        /// Separation of 48 points.
+        case spacing600 = 48
+        /// Separation of 56 points.
+        case spacing700 = 56
+        /// Separation of 64 points.
+        case spacing800 = 64
+        /// Separation of 72 points.
+        case spacing900 = 72
+        /// Separation of 80 points.
+        case spacing1000 = 80
+        /// Separation of 88 points.
+        case spacing1100 = 88
+        /// Separation of 96 points.
+        case spacing1200 = 96
+        /// Separation of 112 points.
+        case spacing1400 = 112
+        /// Separation of 128 points.
+        case spacing1600 = 128
+    }
+}


### PR DESCRIPTION
Introducing `Spacing` and `Border` 🎉 

With the new enums we are now able to specify values for padding and sizes like: `Warp.Spacing.spacing100` and `Warp.Border.borderRadius50`.

I know on Android they choose names like `space025`, `space1`, `space8`. 
But after some chatting with @pbodsk and Christian Therkelsen, we choose to go with `spacing25`, `spacing100`, `spacing800`, since it's easier to understand what the name represent. 

`spacing25` = 2 (8 / 4)
`spacing50` = 4 (8 / 2)
`spacing100` = 8 <-- baseline
`spacing200` = 16 (8 * 2)
`spacing250` = 20 (8 * 2.5)
`spacing300` = 20 (8 * 3)

We also talked about having all the values in `Warp.Dimensions` but we already have `Warp.Shadow` and `Warp.Typography` so it might make sense to have `Warp.Spacing` and `Warp.Border` as well.

But everything is up for discussion 📣 
