### PR TITLE
Adding Token and UIToken variables to make "shortcuts" for TokenProvider and UITokenProvider

### DIFF
--- a/Sources/Config.swift
+++ b/Sources/Config.swift
@@ -1,6 +1,14 @@
 extension Warp {
+    public static var Token: TokenProvider {
+        return Config.tokenProvider
+    }
+
+    public static var UIToken: UITokenProvider {
+        return Config.uiTokenProvider
+    }
+
     public struct Config {
-        public static var tokenProvider: TokenProvider = {
+        static var tokenProvider: TokenProvider = {
             switch warpTheme {
             case .finn:
                 return FinnTokenProvider()
@@ -10,7 +18,8 @@ extension Warp {
                 return DBATokenProvider()
             }
         }()
-        public static var uiTokenProvider: UITokenProvider = {
+
+        static var uiTokenProvider: UITokenProvider = {
             switch warpTheme {
             case .finn:
                 return FinnUITokenProvider()

--- a/Sources/Config.swift
+++ b/Sources/Config.swift
@@ -8,7 +8,7 @@ extension Warp {
     }
 
     public struct Config {
-        static var tokenProvider: TokenProvider = {
+        public static var tokenProvider: TokenProvider = {
             switch warpTheme {
             case .finn:
                 return FinnTokenProvider()
@@ -19,7 +19,7 @@ extension Warp {
             }
         }()
 
-        static var uiTokenProvider: UITokenProvider = {
+        public static var uiTokenProvider: UITokenProvider = {
             switch warpTheme {
             case .finn:
                 return FinnUITokenProvider()

--- a/Sources/Config.swift
+++ b/Sources/Config.swift
@@ -1,13 +1,6 @@
 extension Warp {
-    public static var Token: TokenProvider {
-        return Config.tokenProvider
-    }
-
-    public static var UIToken: UITokenProvider {
-        return Config.uiTokenProvider
-    }
-
     public struct Config {
+        @available(*, deprecated, message: "Use Warp.Token")
         public static var tokenProvider: TokenProvider = {
             switch warpTheme {
             case .finn:
@@ -19,6 +12,7 @@ extension Warp {
             }
         }()
 
+        @available(*, deprecated, message: "Use Warp.UIToken")
         public static var uiTokenProvider: UITokenProvider = {
             switch warpTheme {
             case .finn:
@@ -31,7 +25,7 @@ extension Warp {
         }()
         
         public static var colorProvider: ColorProvider = {
-            ColorProvider(token: tokenProvider)
+            ColorProvider(token: Warp.Token)
         }()
 
         public static var warpTheme: Theme = .finn {

--- a/Sources/Warp.swift
+++ b/Sources/Warp.swift
@@ -1,4 +1,26 @@
 import Foundation
 
 /// Namespace.
-public enum Warp {}
+public enum Warp {
+    public static var Token: TokenProvider = {
+        switch Config.warpTheme {
+        case .finn:
+            return FinnTokenProvider()
+        case .tori:
+            return ToriTokenProvider()
+        case .dba:
+            return DBATokenProvider()
+        }
+    }()
+
+    public static var UIToken: UITokenProvider = {
+        switch Config.warpTheme {
+        case .finn:
+            return FinnUITokenProvider()
+        case .tori:
+            return ToriUITokenProvider()
+        case .dba:
+            return DBAUITokenProvider()
+        }
+    }()
+}


### PR DESCRIPTION
I think we talked about it before @mohsen-schibsted. That it would be great if developers only needed to type `Warp.Token.text` instead of `Warp.Config.tokenProvider.text`.

This PR is a suggestion to make new public variables that the developers should use, instead of using the variables from `Config`.

Later we should remove the public keyword from the variables in `Config`. 
Since this is a breaking change, I haven't removed the public keyword. 

Let's have a discussion if we should call it something different? 
And what about colors. Should they also be public available?