### PR TITLE
Change Spacing and Border to use let instead to avoid using rawValue on enum cases

### DIFF
--- a/Sources/Border/Border.swift
+++ b/Sources/Border/Border.swift
@@ -1,40 +1,40 @@
 import CoreFoundation
 
 extension Warp {
-    public enum Border: CGFloat {
+    public enum Border {
         /// Border radius of 2 points.
-        case borderRadius25
+        public static let borderRadius25: CGFloat = 2
         /// Border radius of 4 points.
-        case borderRadius50
+        public static let borderRadius50: CGFloat = 4
         /// Border radius of 8 points.
-        case borderRadius100
+        public static let borderRadius100: CGFloat = 8
         /// Border radius of 16 points.
-        case borderRadius200
+        public static let borderRadius200: CGFloat = 16
 
         /// Border width of 1 points.
-        case borderWidth12
+        public static let borderWidth12: CGFloat = 1
         /// Border width of 2 points.
-        case borderWidth25
+        public static let borderWidth25: CGFloat = 2
         /// Border width of 4 points.
-        case borderWidth50
+        public static let borderWidth50: CGFloat = 4
 
-        var description: CGFloat {
-            switch self {
-            case .borderRadius25:
-                return 2
-            case .borderRadius50:
-                return 4
-            case .borderRadius100:
-                return 8
-            case .borderRadius200:
-                return 16
-            case .borderWidth12:
-                return 1
-            case .borderWidth25:
-                return 2
-            case .borderWidth50:
-                return 4
-            }
-        }
+//        var description: CGFloat {
+//            switch self {
+//            case .borderRadius25:
+//                return 2
+//            case .borderRadius50:
+//                return 4
+//            case .borderRadius100:
+//                return 8
+//            case .borderRadius200:
+//                return 16
+//            case .borderWidth12:
+//                return 1
+//            case .borderWidth25:
+//                return 2
+//            case .borderWidth50:
+//                return 4
+//            }
+//        }
     }
 }

--- a/Sources/Border/Border.swift
+++ b/Sources/Border/Border.swift
@@ -17,24 +17,5 @@ extension Warp {
         public static let borderWidth25: CGFloat = 2
         /// Border width of 4 points.
         public static let borderWidth50: CGFloat = 4
-
-//        var description: CGFloat {
-//            switch self {
-//            case .borderRadius25:
-//                return 2
-//            case .borderRadius50:
-//                return 4
-//            case .borderRadius100:
-//                return 8
-//            case .borderRadius200:
-//                return 16
-//            case .borderWidth12:
-//                return 1
-//            case .borderWidth25:
-//                return 2
-//            case .borderWidth50:
-//                return 4
-//            }
-//        }
     }
 }

--- a/Sources/Spacing/Spacing.swift
+++ b/Sources/Spacing/Spacing.swift
@@ -1,42 +1,42 @@
 import CoreFoundation
 
 extension Warp {
-    public enum Spacing: CGFloat {
+    public enum Spacing {
         /// Separation of 2 points.
-        case spacing25 = 2
+        public static let spacing25: CGFloat = 2
         /// Separation of 4 points.
-        case spacing50 = 4
+        public static let spacing50: CGFloat = 4
         /// Separation of 8 points.
-        case spacing100 = 8
+        public static let spacing100: CGFloat = 8
         /// Separation of 12 points.
-        case spacing150 = 12
+        public static let spacing150: CGFloat = 12
         /// Separation of 16 points.
-        case spacing200 = 16
+        public static let spacing200: CGFloat = 16
         /// Separation of 20 points.
-        case spacing250 = 20
+        public static let spacing250: CGFloat = 20
         /// Separation of 24 points.
-        case spacing300 = 24
+        public static let spacing300: CGFloat = 24
         /// Separation of 32 points.
-        case spacing400 = 32
+        public static let spacing400: CGFloat = 32
         /// Separation of 40 points.
-        case spacing500 = 40
+        public static let spacing500: CGFloat = 40
         /// Separation of 48 points.
-        case spacing600 = 48
+        public static let spacing600: CGFloat = 48
         /// Separation of 56 points.
-        case spacing700 = 56
+        public static let spacing700: CGFloat = 56
         /// Separation of 64 points.
-        case spacing800 = 64
+        public static let spacing800: CGFloat = 64
         /// Separation of 72 points.
-        case spacing900 = 72
+        public static let spacing900: CGFloat = 72
         /// Separation of 80 points.
-        case spacing1000 = 80
+        public static let spacing1000: CGFloat = 80
         /// Separation of 88 points.
-        case spacing1100 = 88
+        public static let spacing1100: CGFloat = 88
         /// Separation of 96 points.
-        case spacing1200 = 96
+        public static let spacing1200: CGFloat = 96
         /// Separation of 112 points.
-        case spacing1400 = 112
+        public static let spacing1400: CGFloat = 112
         /// Separation of 128 points.
-        case spacing1600 = 128
+        public static let spacing1600: CGFloat = 128
     }
 }


### PR DESCRIPTION
I made a mistake when choosing to use enum cases. We need to get the value with `.rawValue` and that was not the intention.

Use changing all values to static let instead, just to keep it simple.