### PR TITLE
Make Color extension public

### DIFF
--- a/Sources/Colors/Tokens/TokenProvider.swift
+++ b/Sources/Colors/Tokens/TokenProvider.swift
@@ -350,7 +350,7 @@ public extension UIColor {
     }
 }
 
-extension Color {
+public extension Color {
     init(hex: String) {
         let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
         var int: UInt64 = 0


### PR DESCRIPTION
I'm currently facing this lovely error: `Ambiguous use of 'init(hex:)'` when we import both `Warp`and `FinniversKit`.
I quick workaround is to use the `Color` extension, so I need it to be public. 

Next step must be to make the extension for `UIColor` in `FinniversKit` not public.

Anyone have other suggestions? We might end up with a similar conflict with another library.. 🤔 