### PR TITLE
Feature/expandable

### DIFF
--- a/SampleApp/AlertView.swift
+++ b/SampleApp/AlertView.swift
@@ -95,6 +95,7 @@ struct AlertView: View {
                 )
             }
             .padding(.horizontal, 20)
+            .navigationTitle("Alert")
         }
     }
 

--- a/SampleApp/BadgeView.swift
+++ b/SampleApp/BadgeView.swift
@@ -8,6 +8,7 @@ struct BadgeView: View {
                 createView(for: variant)
             }
             .padding(.horizontal)
+            .navigationTitle("Badge")
         }
     }
 

--- a/SampleApp/BoxView.swift
+++ b/SampleApp/BoxView.swift
@@ -110,6 +110,7 @@ struct BoxView: View {
                 )
             }
             .padding(.horizontal, 20)
+            .navigationTitle("Box")
         }
     }
 

--- a/SampleApp/BroadcastView.swift
+++ b/SampleApp/BroadcastView.swift
@@ -64,6 +64,7 @@ struct BroadcastView: View {
             }
         }
         .padding()
+        .navigationTitle("Broadcast")
         .warpBroadcast(
             text: "Here's a broadcast located at the \(broadcastEdge.description) edge",
             edge: broadcastEdge,

--- a/SampleApp/ButtonView.swift
+++ b/SampleApp/ButtonView.swift
@@ -64,6 +64,7 @@ struct ButtonView: View {
             Divider()
         }
         .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle("Button")
         .padding(.horizontal, 20)
     }
     

--- a/SampleApp/CalloutView.swift
+++ b/SampleApp/CalloutView.swift
@@ -25,6 +25,7 @@ struct CalloutView: View {
             }
         }
         .padding()
+        .navigationTitle("Callout")
     }
 
     private var inlineViews: some View {

--- a/SampleApp/ExpandableView.swift
+++ b/SampleApp/ExpandableView.swift
@@ -4,10 +4,12 @@ import Warp
 struct ExpandableView: View {
     @State var expandableStyle: Warp.ExpandableStyle = .default
     @State var isAnimated = true
+    @State var title: String = "Title"
+    @State var subTitle: String = "Subtitle"
 
     var body: some View {
-        VStack {
-            Warp.Text("Expandable Stype", style: .title2)
+        VStack(alignment: .leading) {
+            Warp.Text("Select an expandable style", style: .bodyStrong)
             Picker("Expandable Style", selection: $expandableStyle) {
                 ForEach([
                     Warp.ExpandableStyle.default,
@@ -20,20 +22,27 @@ struct ExpandableView: View {
             .pickerStyle(.segmented)
 
             Toggle(isOn: $isAnimated, label: {
-                Warp.Text("Animated", style: .body)
+                Warp.Text("Animated", style: .bodyStrong)
             })
 
+            VStack {
+                Warp.TextField(text: $title)
+                Warp.TextField(text: $subTitle)
+            }
+            .autocorrectionDisabled()
+            .frame(height: 100)
+
             Warp.Expandable(
-                title: "Title",
-                subtitle: "Subtitle, which is long so we need to span over more than one line",
+                title: title,
+                subtitle: subTitle,
                 style: expandableStyle,
                 isAnimated: isAnimated
             )
 
-            Warp.Text("How does it look with text underneath?", style: .body)
             Spacer()
         }
         .padding()
+        .navigationTitle("Expandable")
     }
 }
 

--- a/SampleApp/ExpandableView.swift
+++ b/SampleApp/ExpandableView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import Warp
+
+struct ExpandableView: View {
+    @State var expandableStyle: Warp.ExpandableStyle = .default
+    @State var isAnimated = true
+
+    var body: some View {
+        VStack {
+            Warp.Text("Expandable Stype", style: .title2)
+            Picker("Expandable Style", selection: $expandableStyle) {
+                ForEach([
+                    Warp.ExpandableStyle.default,
+                    Warp.ExpandableStyle.box,
+                    Warp.ExpandableStyle.boxBleed,
+                ], id: \.self) { style in
+                    Text(style.description)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Toggle(isOn: $isAnimated, label: {
+                Warp.Text("Animated", style: .body)
+            })
+
+            Warp.Expandable(
+                title: "Title",
+                subtitle: "Subtitle, which is long so we need to span over more than one line",
+                style: expandableStyle,
+                isAnimated: isAnimated
+            )
+
+            Warp.Text("How does it look with text underneath?", style: .body)
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+fileprivate extension Warp.ExpandableStyle {
+    var description: String {
+        switch self {
+        case .default:
+            "Default"
+        case .box:
+            "Box"
+        case .boxBleed:
+            "Box Bleed"
+        }
+    }
+}
+
+#Preview {
+    ExpandableView()
+}

--- a/SampleApp/ExpandableView.swift
+++ b/SampleApp/ExpandableView.swift
@@ -33,9 +33,9 @@ struct ExpandableView: View {
             .frame(height: 100)
 
             Warp.Expandable(
+                style: expandableStyle,
                 title: title,
                 subtitle: subTitle,
-                style: expandableStyle,
                 isAnimated: isAnimated
             )
 

--- a/SampleApp/ModalView.swift
+++ b/SampleApp/ModalView.swift
@@ -119,6 +119,7 @@ struct ModalView: View {
                 }
                 .padding(.horizontal, 20)
             }
+            .navigationTitle("Modal")
         }
         
         .warpModal(

--- a/SampleApp/PillView.swift
+++ b/SampleApp/PillView.swift
@@ -8,6 +8,7 @@ struct PillView: View {
                 createView(for: style)
             }
             .padding(.horizontal)
+            .navigationTitle("Pill")
         }
     }
     

--- a/SampleApp/ShadowView.swift
+++ b/SampleApp/ShadowView.swift
@@ -38,6 +38,7 @@ struct ShadowView: View {
                 .padding()
             }
         }
+        .navigationTitle("Shadow")
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/SampleApp/SpinnerView.swift
+++ b/SampleApp/SpinnerView.swift
@@ -9,6 +9,7 @@ struct SpinnerView: View {
             Warp.Spinner(size: .large)
             Warp.Spinner(size: .custom(50))
         }
+        .navigationTitle("Spinner")
     }
 }
 

--- a/SampleApp/StepIndicatorView.swift
+++ b/SampleApp/StepIndicatorView.swift
@@ -124,6 +124,7 @@ struct StepIndicatorView: View {
             edge: .top,
             isPresented: $toastIsPresented
         )
+        .navigationTitle("Step Indicator")
     }
 
     private func pushStep() {

--- a/SampleApp/TextFieldView.swift
+++ b/SampleApp/TextFieldView.swift
@@ -109,6 +109,7 @@ struct TextFieldView: View {
             }
             .padding(.horizontal)
             .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle("TextField")
             .onChange(of: informationState) { newInformationState in
                 UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
                 

--- a/SampleApp/ToastView.swift
+++ b/SampleApp/ToastView.swift
@@ -89,6 +89,7 @@ struct ToastView: View {
             edge: toastEdge,
             isPresented: $toastIsPresented
         )
+        .navigationTitle("Toast")
     }
 
     private var toastStatus: String {

--- a/SampleApp/Warp-iosFinn/ContentView.swift
+++ b/SampleApp/Warp-iosFinn/ContentView.swift
@@ -100,6 +100,13 @@ struct ContentView: View {
 
                     Divider()
 
+                    NavigationLink(destination: ExpandableView()) {
+                        Text("Expandable")
+                            .padding()
+                    }
+
+                    Divider()
+
                     NavigationLink(destination: PillView()) {
                         Text("Pill")
                             .padding()

--- a/SampleApp/Warp-iosSampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/Warp-iosSampleApp.xcodeproj/project.pbxproj
@@ -72,6 +72,9 @@
 		82B168132B750BED00DCDDE5 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B168112B750BED00DCDDE5 /* TextView.swift */; };
 		82C7E6F52B7B85E000760C08 /* BroadcastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C7E6F42B7B85E000760C08 /* BroadcastView.swift */; };
 		82C7E6F62B7B883200760C08 /* BroadcastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C7E6F42B7B85E000760C08 /* BroadcastView.swift */; };
+		B238A26E2C2EB60A00CD1CAC /* ExpandableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B238A26D2C2EB60A00CD1CAC /* ExpandableView.swift */; };
+		B238A26F2C2EB60A00CD1CAC /* ExpandableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B238A26D2C2EB60A00CD1CAC /* ExpandableView.swift */; };
+		B238A2702C2EB60A00CD1CAC /* ExpandableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B238A26D2C2EB60A00CD1CAC /* ExpandableView.swift */; };
 		B2922A6E2B68E7F200A3E9F4 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2922A6D2B68E7F200A3E9F4 /* ToastView.swift */; };
 		B2922A6F2B68E7F200A3E9F4 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2922A6D2B68E7F200A3E9F4 /* ToastView.swift */; };
 		B295AC3A2C22F93D004C77BB /* StepIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B295AC392C22F93D004C77BB /* StepIndicatorView.swift */; };
@@ -112,6 +115,7 @@
 		82A2155B2A8DF93B0062FB9E /* TextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldView.swift; sourceTree = "<group>"; };
 		82B168112B750BED00DCDDE5 /* TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
 		82C7E6F42B7B85E000760C08 /* BroadcastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastView.swift; sourceTree = "<group>"; };
+		B238A26D2C2EB60A00CD1CAC /* ExpandableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandableView.swift; sourceTree = "<group>"; };
 		B2922A6D2B68E7F200A3E9F4 /* ToastView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		B295AC392C22F93D004C77BB /* StepIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepIndicatorView.swift; sourceTree = "<group>"; };
 		B2A8B2782B6D33B800122DBC /* CalloutView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalloutView.swift; sourceTree = "<group>"; };
@@ -227,6 +231,7 @@
 				349D0E122B62D67A00AAB421 /* AlertView.swift */,
 				82A2155B2A8DF93B0062FB9E /* TextFieldView.swift */,
 				B295AC392C22F93D004C77BB /* StepIndicatorView.swift */,
+				B238A26D2C2EB60A00CD1CAC /* ExpandableView.swift */,
 				82B168112B750BED00DCDDE5 /* TextView.swift */,
 				2E1ADF472C25612300DFEE06 /* GoogleService-Info.plist */,
 				82355B082A8CD0AA0023EB11 /* Assets.xcassets */,
@@ -399,6 +404,7 @@
 				2E1ADF572C2561A700DFEE06 /* PillView.swift in Sources */,
 				2E1ADF582C2561A700DFEE06 /* ShadowView.swift in Sources */,
 				2E1ADF592C2561A700DFEE06 /* AlertView.swift in Sources */,
+				B238A2702C2EB60A00CD1CAC /* ExpandableView.swift in Sources */,
 				2E1ADF5A2C2561A700DFEE06 /* BoxView.swift in Sources */,
 				2E1ADF5B2C2561A700DFEE06 /* ButtonView.swift in Sources */,
 				2E1ADF5C2C2561A700DFEE06 /* ToastView.swift in Sources */,
@@ -415,6 +421,7 @@
 				B295AC3A2C22F93D004C77BB /* StepIndicatorView.swift in Sources */,
 				82B168122B750BED00DCDDE5 /* TextView.swift in Sources */,
 				003CB8E92C19B5D5008C42B1 /* ModalView.swift in Sources */,
+				B238A26E2C2EB60A00CD1CAC /* ExpandableView.swift in Sources */,
 				828E7D452B61239100869C58 /* BadgeView.swift in Sources */,
 				82A2155C2A8DF93B0062FB9E /* TextFieldView.swift in Sources */,
 				B2A8B2792B6D33B800122DBC /* CalloutView.swift in Sources */,
@@ -440,6 +447,7 @@
 				B295AC3B2C22F93D004C77BB /* StepIndicatorView.swift in Sources */,
 				828E7D462B61239100869C58 /* BadgeView.swift in Sources */,
 				00BC50DB2C2C050D002C4FF0 /* ModalView.swift in Sources */,
+				B238A26F2C2EB60A00CD1CAC /* ExpandableView.swift in Sources */,
 				82355B112A8CD0C10023EB11 /* Warp_iosTori.swift in Sources */,
 				82C7E6F62B7B883200760C08 /* BroadcastView.swift in Sources */,
 				B2A8B27A2B6D33B800122DBC /* CalloutView.swift in Sources */,

--- a/SampleApp/Warp-iosSampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/Warp-iosSampleApp.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		B238A26E2C2EB60A00CD1CAC /* ExpandableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B238A26D2C2EB60A00CD1CAC /* ExpandableView.swift */; };
 		B238A26F2C2EB60A00CD1CAC /* ExpandableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B238A26D2C2EB60A00CD1CAC /* ExpandableView.swift */; };
 		B238A2702C2EB60A00CD1CAC /* ExpandableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B238A26D2C2EB60A00CD1CAC /* ExpandableView.swift */; };
+		B286EDFC2C33EACF00D25DCC /* StepIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B295AC392C22F93D004C77BB /* StepIndicatorView.swift */; };
 		B2922A6E2B68E7F200A3E9F4 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2922A6D2B68E7F200A3E9F4 /* ToastView.swift */; };
 		B2922A6F2B68E7F200A3E9F4 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2922A6D2B68E7F200A3E9F4 /* ToastView.swift */; };
 		B295AC3A2C22F93D004C77BB /* StepIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B295AC392C22F93D004C77BB /* StepIndicatorView.swift */; };
@@ -393,6 +394,7 @@
 				2E1ADF4E2C2561A700DFEE06 /* TypographyView.swift in Sources */,
 				2E1ADF4F2C2561A700DFEE06 /* TextView.swift in Sources */,
 				2E1ADF722C2561D200DFEE06 /* Warp_iosDBA.swift in Sources */,
+				B286EDFC2C33EACF00D25DCC /* StepIndicatorView.swift in Sources */,
 				00BC50DC2C2C0AD0002C4FF0 /* ModalView.swift in Sources */,
 				2E1ADF502C2561A700DFEE06 /* BadgeView.swift in Sources */,
 				2E1ADF522C2561A700DFEE06 /* BroadcastView.swift in Sources */,

--- a/Sources/Colors/ColorProvider.swift
+++ b/Sources/Colors/ColorProvider.swift
@@ -416,6 +416,7 @@ public struct ColorProvider {
     /// Expandable
     var expandableTitleText: Color { token.text }
     var expandableParagraphText: Color { token.text }
+    var expandableDefaultBackground: Color { token.background }
     var expandableBackground: Color { token.backgroundSubtle }
     var expandableBackgroundHover: Color { token.backgroundSubtleHover }
     var expandableIcon: Color { token.icon }

--- a/Sources/Colors/ColorProvider.swift
+++ b/Sources/Colors/ColorProvider.swift
@@ -416,7 +416,6 @@ public struct ColorProvider {
     /// Expandable
     var expandableTitleText: Color { token.text }
     var expandableParagraphText: Color { token.text }
-    var expandableDefaultBackground: Color { token.background }
     var expandableBackground: Color { token.backgroundSubtle }
     var expandableBackgroundHover: Color { token.backgroundSubtleHover }
     var expandableIcon: Color { token.icon }

--- a/Sources/Components/Expandable/Expandable.swift
+++ b/Sources/Components/Expandable/Expandable.swift
@@ -31,7 +31,6 @@ extension Warp {
          Starting in a collapsed state gives the user a high-level overview of the available information.
         */
         @State private var isExpanded: Bool = false
-        @State private var opacity: Double = 0.0
 
         private let fadeAnimationTime: Double = 0.1
         private let expandAnimationTime: Double = 0.2
@@ -97,28 +96,19 @@ extension Warp {
             .onTapGesture {
                 if isExpanded {
                     if isAnimated {
-                        withAnimation(.easeIn(duration: fadeAnimationTime)) {
-                            opacity = 0
-                        }
-
-                        withAnimation(.easeOut(duration: expandAnimationTime).delay(fadeAnimationTime)) {
+                        withAnimation(.easeInOut) {
                             isExpanded = false
                         }
                     } else {
-                        opacity = 0
                         isExpanded = false
                     }
                 } else {
                     if isAnimated {
-                        withAnimation(.easeIn(duration: expandAnimationTime)){
+                        withAnimation(.easeInOut) {
                             isExpanded = true
-                        }
-                        withAnimation(.easeOut(duration: fadeAnimationTime).delay(expandAnimationTime)) {
-                            opacity = 1
                         }
                     } else {
                         isExpanded = true
-                        opacity = 1
                     }
                 }
             }
@@ -137,7 +127,6 @@ extension Warp {
                 }
             }
             .fixedSize(horizontal: false, vertical: true)
-            .opacity(opacity)
         }
     }
 }

--- a/Sources/Components/Expandable/Expandable.swift
+++ b/Sources/Components/Expandable/Expandable.swift
@@ -1,30 +1,55 @@
 import SwiftUI
 
 extension Warp {
-    public struct Expandable: View{
-        @State var isExpanded: Bool = false
-        @State var opacity: Double = 0.0
+    /**
 
-        let fadeAnimationTime: Double = 0.1
-        let expandAnimationTime: Double = 0.2
+    Expandable allows users to interact with expandable/collapsible sections of content. Also known as “accordion”
+
+    **When to use**
+
+     Use the Expandable component when presenting content that can be optionally revealed to users.
+     Consider it for long content that may overwhelm users if displayed all at once.
+
+     **Usage**
+
+     Provide the `Warp.Expandable` with:
+
+     - A title.
+     - A subtitle.
+     - A `Warp.ExpandableStyle`, choose from:
+        - `default`: for a non bordered expandable.
+        - `box`: for a bordered expandable with rounded corners.
+        - `boxBleed`: for a bordered expandable with sharp corners.
+     - A boolean `isAnimated` to determine if the expand/collapse transition is animated or not. **Optional** _default value is `true` if none is specified_.
+     - A `ColorProvider`. **Optional:** _default is read from `Config.colorProvider` if none is specified_.
+     */
+    public struct Expandable: View {
+        /**
+        **Collapsed by default**
+
+         Expendables begins in the collapsed state with all content panels closed.
+         Starting in a collapsed state gives the user a high-level overview of the available information.
+        */
+        @State private var isExpanded: Bool = false
+        @State private var opacity: Double = 0.0
+
+        private let fadeAnimationTime: Double = 0.1
+        private let expandAnimationTime: Double = 0.2
 
         let title: String
         let subtitle: String
         let style: Warp.ExpandableStyle
         let isAnimated: Bool
 
-        /// Object responsible for providing colors in different environments and variants.
-        var colorProvider: ColorProvider = Config.colorProvider
+        let colorProvider: ColorProvider
 
         public init(
-            isExpanded: Bool = false, // default value, not sure if this should be exposed actually
             title: String,
             subtitle: String,
             style: Warp.ExpandableStyle,
             isAnimated: Bool = true,
             colorProvider: ColorProvider = Config.colorProvider
         ) {
-            self.isExpanded = isExpanded
             self.title = title
             self.subtitle = subtitle
             self.style = style
@@ -32,9 +57,8 @@ extension Warp {
             self.colorProvider = colorProvider
         }
 
-        #warning("Rebase and use Warp.Spacing")
         public var body: some View {
-            VStack(spacing: 16) {
+            VStack(spacing: Warp.Spacing.spacing200) {
                 alwaysVisibleView
 
                 if isExpanded {
@@ -42,7 +66,7 @@ extension Warp {
                 }
             }
             .frame(maxWidth: .infinity)
-            .padding(16)
+            .padding(Warp.Spacing.spacing200)
             .background(style.backgroundColor(using: colorProvider))
             .cornerRadius(style.cornerRadius)
         }
@@ -112,7 +136,7 @@ extension Warp {
                     Spacer()
                 }
             }
-            .padding(.top, 16)
+            .fixedSize(horizontal: false, vertical: true)
             .opacity(opacity)
         }
     }

--- a/Sources/Components/Expandable/Expandable.swift
+++ b/Sources/Components/Expandable/Expandable.swift
@@ -26,13 +26,7 @@ extension Warp {
      - A `ColorProvider`. **Optional:** _default is read from `Config.colorProvider` if none is specified_.
      */
     public struct Expandable<Content: View>: View {
-        /**
-         **Collapsed by default**
-
-         Expendables begins in the collapsed state with all content panels closed.
-         Starting in a collapsed state gives the user a high-level overview of the available information.
-         */
-        @State private var isExpanded: Bool = false
+        @State private var isExpanded: Bool
 
         let title: String
 
@@ -48,12 +42,14 @@ extension Warp {
             title: String,
             @ViewBuilder expandableView: () -> Content,
             isAnimated: Bool = true,
+            isExpanded: Bool = false,
             colorProvider: ColorProvider = Config.colorProvider
         ) {
             self.style = style
             self.title = title
             self.expandableView = expandableView()
             self.isAnimated = isAnimated
+            self.isExpanded = isExpanded
             self.colorProvider = colorProvider
         }
 
@@ -116,6 +112,7 @@ extension Warp.Expandable where Content == Warp.ExpandableStringWrapperView {
         title: String,
         subtitle: String,
         isAnimated: Bool = true,
+        isExpanded: Bool = false,
         colorProvider: ColorProvider = Warp.Config.colorProvider
     ) {
         self.init(
@@ -123,6 +120,7 @@ extension Warp.Expandable where Content == Warp.ExpandableStringWrapperView {
             title: title,
             expandableView: { Warp.ExpandableStringWrapperView(subtitle: subtitle, colorProvider: colorProvider) },
             isAnimated: isAnimated,
+            isExpanded: isExpanded,
             colorProvider: colorProvider
         )
     }
@@ -154,7 +152,7 @@ public extension Warp {
     }
 }
 
-extension Warp.Expandable {
+extension Warp {
     // This allows us to have a button for the alwaysVisible part that doesn't
     // hightlight/flash when tapped
     fileprivate struct NonHighlightedButtonStyle: ButtonStyle {
@@ -168,7 +166,16 @@ extension Warp.Expandable {
     Warp.Expandable(
         style: .default,
         title: "Expandable box",
-        subtitle: "Add your text here. Add your text here. Add your text here. Add your text here. Add your text here. Add your text here. "
+        subtitle: "Add your text here. Add your text here. Add your text here. Add your text here. Add your text here. Add your text here."
+    )
+}
+
+#Preview("Default -  Expanded") {
+    Warp.Expandable(
+        style: .default,
+        title: "Expandable box",
+        subtitle: "Add your text here. Add your text here. Add your text here. Add your text here. Add your text here. Add your text here.",
+        isExpanded: true
     )
 }
 
@@ -184,7 +191,7 @@ extension Warp.Expandable {
     Warp.Expandable(
         style: .boxBleed,
         title: "Expandable box",
-        subtitle: "Add your text here. Add your text here. Add your text here. Add your text here. Add your text here. Add your text here. "
+        subtitle: "Add your text here. Add your text here. Add your text here. Add your text here. Add your text here. Add your text here."
     )
 }
 
@@ -198,4 +205,3 @@ extension Warp.Expandable {
             .foregroundStyle(.red)
     }
 }
-

--- a/Sources/Components/Expandable/Expandable.swift
+++ b/Sources/Components/Expandable/Expandable.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+extension Warp {
+    public struct Expandable: View{
+        @State var isExpanded: Bool = false
+        @State var opacity: Double = 0.0
+
+        let fadeAnimationTime: Double = 0.1
+        let expandAnimationTime: Double = 0.2
+
+        let title: String
+        let subtitle: String
+        let style: Warp.ExpandableStyle
+        let isAnimated: Bool
+
+        /// Object responsible for providing colors in different environments and variants.
+        var colorProvider: ColorProvider = Config.colorProvider
+
+        public init(
+            isExpanded: Bool = false, // default value, not sure if this should be exposed actually
+            title: String,
+            subtitle: String,
+            style: Warp.ExpandableStyle,
+            isAnimated: Bool = true,
+            colorProvider: ColorProvider = Config.colorProvider
+        ) {
+            self.isExpanded = isExpanded
+            self.title = title
+            self.subtitle = subtitle
+            self.style = style
+            self.isAnimated = isAnimated
+            self.colorProvider = colorProvider
+        }
+
+        #warning("Rebase and use Warp.Spacing")
+        public var body: some View {
+            VStack(spacing: 16) {
+                alwaysVisibleView
+
+                if isExpanded {
+                    expandableView
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(16)
+            .background(style.backgroundColor(using: colorProvider))
+            .cornerRadius(style.cornerRadius)
+        }
+
+        @ViewBuilder private var alwaysVisibleView: some View {
+            HStack {
+                Warp.Text(
+                    title,
+                    style: .bodyStrong,
+                    color: colorProvider.expandableTitleText
+                )
+
+                if style != .default {
+                    Spacer()
+                }
+
+                Image("icon-expandable-chevron", bundle: .module)
+                    .renderingMode(.template)
+                    .foregroundColor(colorProvider.expandableIcon)
+                    .frame(width: 16, height: 16)
+                    .rotationEffect(.degrees(isExpanded ? 180 : 0))
+
+                if style == .default {
+                    Spacer()
+                }
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                if isExpanded {
+                    if isAnimated {
+                        withAnimation(.easeIn(duration: fadeAnimationTime)) {
+                            opacity = 0
+                        }
+
+                        withAnimation(.easeOut(duration: expandAnimationTime).delay(fadeAnimationTime)) {
+                            isExpanded = false
+                        }
+                    } else {
+                        opacity = 0
+                        isExpanded = false
+                    }
+                } else {
+                    if isAnimated {
+                        withAnimation(.easeIn(duration: expandAnimationTime)){
+                            isExpanded = true
+                        }
+                        withAnimation(.easeOut(duration: fadeAnimationTime).delay(expandAnimationTime)) {
+                            opacity = 1
+                        }
+                    } else {
+                        isExpanded = true
+                        opacity = 1
+                    }
+                }
+            }
+        }
+
+        @ViewBuilder private var expandableView: some View {
+            VStack(spacing: 0) {
+                HStack {
+                    Warp.Text(
+                        subtitle,
+                        style: .body,
+                        color: colorProvider.expandableParagraphText
+                    )
+
+                    Spacer()
+                }
+            }
+            .padding(.top, 16)
+            .opacity(opacity)
+        }
+    }
+}
+
+#Preview("Default") {
+    Warp.Expandable(
+        title: "Expandable box",
+        subtitle: "Add your text here. Add your text here. Add your text here. Add your text here. Add your text here. Add your text here. ",
+        style: .default
+    )
+}
+
+#Preview("Box") {
+    Warp.Expandable(
+        title: "Expandable box",
+        subtitle: "Add your text here. ",
+        style: .box
+    )
+}
+#Preview("Box Bleed") {
+    Warp.Expandable(
+        title: "Expandable box",
+        subtitle: "Add your text here. Add your text here. Add your text here. Add your text here. Add your text here. Add your text here. ",
+        style: .boxBleed
+    )
+}

--- a/Sources/Components/Expandable/Expandable.swift
+++ b/Sources/Components/Expandable/Expandable.swift
@@ -109,6 +109,7 @@ extension Warp {
     }
 }
 
+// We need this to allow us to create an `Expandable` from a simple String
 extension Warp.Expandable where Content == Warp.ExpandableStringWrapperView {
     public init(
         style: Warp.ExpandableStyle,
@@ -128,6 +129,10 @@ extension Warp.Expandable where Content == Warp.ExpandableStringWrapperView {
 }
 
 public extension Warp {
+    /*
+     This is a simple wrapper view to ensure that our `subtitle` String 
+     looks pretty
+     */
     struct ExpandableStringWrapperView: View {
         let subtitle: String
         let colorProvider: ColorProvider
@@ -149,9 +154,13 @@ public extension Warp {
     }
 }
 
-fileprivate struct NonHighlightedButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
+extension Warp.Expandable {
+    // This allows us to have a button for the alwaysVisible part that doesn't
+    // hightlight/flash when tapped
+    fileprivate struct NonHighlightedButtonStyle: ButtonStyle {
+        func makeBody(configuration: Configuration) -> some View {
+            configuration.label
+        }
     }
 }
 

--- a/Sources/Components/Expandable/Expandable.swift
+++ b/Sources/Components/Expandable/Expandable.swift
@@ -32,9 +32,6 @@ extension Warp {
         */
         @State private var isExpanded: Bool = false
 
-        private let fadeAnimationTime: Double = 0.1
-        private let expandAnimationTime: Double = 0.2
-
         let title: String
         let subtitle: String
         let style: Warp.ExpandableStyle
@@ -94,22 +91,12 @@ extension Warp {
             }
             .contentShape(Rectangle())
             .onTapGesture {
-                if isExpanded {
-                    if isAnimated {
-                        withAnimation(.easeInOut) {
-                            isExpanded = false
-                        }
-                    } else {
-                        isExpanded = false
+                if isAnimated {
+                    withAnimation(.easeInOut) {
+                        isExpanded.toggle()
                     }
                 } else {
-                    if isAnimated {
-                        withAnimation(.easeInOut) {
-                            isExpanded = true
-                        }
-                    } else {
-                        isExpanded = true
-                    }
+                    isExpanded.toggle()
                 }
             }
         }

--- a/Sources/Components/Expandable/ExpandableStyle.swift
+++ b/Sources/Components/Expandable/ExpandableStyle.swift
@@ -14,7 +14,7 @@ extension Warp {
         func backgroundColor(using colorProvider: ColorProvider) -> Color {
             switch self {
             case .default:
-                colorProvider.expandableDefaultBackground
+                .clear
             case .box, .boxBleed:
                 colorProvider.expandableBackground
             }

--- a/Sources/Components/Expandable/ExpandableStyle.swift
+++ b/Sources/Components/Expandable/ExpandableStyle.swift
@@ -2,8 +2,13 @@ import SwiftUI
 
 extension Warp {
     public enum ExpandableStyle {
+        /// Basic expandable component.
         case `default`
+
+        /// Expandable component with a boxed layout. Round corners
         case box
+
+        /// Expandable component with a boxed layout. Square corners
         case boxBleed
 
         func backgroundColor(using colorProvider: ColorProvider) -> Color {

--- a/Sources/Components/Expandable/ExpandableStyle.swift
+++ b/Sources/Components/Expandable/ExpandableStyle.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+extension Warp {
+    public enum ExpandableStyle {
+        case `default`
+        case box
+        case boxBleed
+
+        func backgroundColor(using colorProvider: ColorProvider) -> Color {
+            switch self {
+            case .default:
+                colorProvider.expandableDefaultBackground
+            case .box, .boxBleed:
+                colorProvider.expandableBackground
+            }
+        }
+        
+        var cornerRadius: Double {
+            switch self {
+            case .default, .boxBleed: 0
+            case .box: 8
+            }
+        }
+    }
+}

--- a/Sources/Components/Expandable/ExpandableStyle.swift
+++ b/Sources/Components/Expandable/ExpandableStyle.swift
@@ -23,7 +23,7 @@ extension Warp {
         var cornerRadius: Double {
             switch self {
             case .default, .boxBleed: 0
-            case .box: 8
+            case .box: Warp.Border.borderRadius100
             }
         }
     }

--- a/Sources/Components/StepIndicator/StepIndicator.swift
+++ b/Sources/Components/StepIndicator/StepIndicator.swift
@@ -10,11 +10,11 @@ extension Warp {
 
         **Usage**
 
-        You need to provide the `Warp.StepIndicator` with:
+        Provide the `Warp.StepIndicator` with:
 
-        - A `Warp.StepIndicator.LayoutOrientation`. **Optional:** _default is `.vertical` if none is specified_
-        - An array of `Warp.StepIndicatorItem`s
-        - A `ColorProvider`. **Optional:** _default is read from `Config.colorProvider` if none is specified_
+        - A `Warp.StepIndicator.LayoutOrientation`. **Optional:** _default is `.vertical` if none is specified_.
+        - An array of `Warp.StepIndicatorItem`s.
+        - A `ColorProvider`. **Optional:** _default is read from `Config.colorProvider` if none is specified_.
 
      */
     public struct StepIndicator: View {
@@ -26,7 +26,6 @@ extension Warp {
 
         let layoutOrientation: LayoutOrientation
 
-        /// Object responsible for providing colors in different environments and variants.
         let colorProvider: ColorProvider
 
         private let orderedSteps: [StepIndicatorModel.OrderedStepIndicatorItem]

--- a/Sources/Components/StepIndicator/Subviews/HorizontalProgressView.swift
+++ b/Sources/Components/StepIndicator/Subviews/HorizontalProgressView.swift
@@ -63,13 +63,13 @@ extension Warp.StepIndicator {
                     EmptyView()
                 }
             case .middle(let previousProgress, _):
-                LineBuilder.line(
+                Warp.StepIndicator.LineBuilder.line(
                     for: previousProgress,
                     ownProgress: progress,
                     orientation: .horizontal
                 )
             case .last(let previousProgress):
-                LineBuilder.line(
+                Warp.StepIndicator.LineBuilder.line(
                     for: previousProgress,
                     ownProgress: progress,
                     orientation: .horizontal
@@ -82,7 +82,7 @@ extension Warp.StepIndicator {
             switch stepPosition {
             case .first(let nextProgress):
                 if let nextProgress {
-                    LineBuilder.line(
+                    Warp.StepIndicator.LineBuilder.line(
                         for: nextProgress,
                         ownProgress: progress,
                         orientation: .horizontal
@@ -91,7 +91,7 @@ extension Warp.StepIndicator {
                     EmptyView()
                 }
             case .middle(_, let nextProgress):
-                LineBuilder.line(
+                Warp.StepIndicator.LineBuilder.line(
                     for: nextProgress,
                     ownProgress: progress,
                     orientation: .horizontal

--- a/Sources/Resources/Assets.xcassets/Expandable/Contents.json
+++ b/Sources/Resources/Assets.xcassets/Expandable/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Resources/Assets.xcassets/Expandable/icon-expandable-chevron.imageset/Contents.json
+++ b/Sources/Resources/Assets.xcassets/Expandable/icon-expandable-chevron.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "icon-expandable-chevron.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Resources/Assets.xcassets/Expandable/icon-expandable-chevron.imageset/icon-expandable-chevron.svg
+++ b/Sources/Resources/Assets.xcassets/Expandable/icon-expandable-chevron.imageset/icon-expandable-chevron.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="ChevronDown">
+<path id="Vector 417" d="M2.66669 5.33331L8.16669 10.8333L13.6667 5.33331" stroke="#47474F" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>


### PR DESCRIPTION
# Expandable Component

This looked like a simple component to implement to I went for it...of course I ended up spending more time than I thought 😅 

## How does it look? 🔍 
Here are a couple of videos showing the various designs of the `Expandable`. 

First with animations enabled:

https://github.com/warp-ds/warp-ios/assets/117636/e39aec05-0f56-4928-ba62-d5d556627abd

And then without animations:

https://github.com/warp-ds/warp-ios/assets/117636/b38c3e8a-aa7f-4784-9a45-062bb6fb8df0

## Reading Order 👀 
Here is a suggested reading order for the files in this PR

### `Expandable`
As always, a good first candidate is the component itself. It is not super complex and consists of two parts

- `alwaysVisibleView`: The top part that is always shown
- `expandableView`: The expanded/collapsed part sitting under the `alwaysVisibleView` part

To control expand/collapse we have a 

`@State private var isExpanded: Bool = false`

that is then toggled by a `.onTapGesture` on the `alwaysVisibleView`.

Note that we have to determine if the user wants this part to be animated or not:

```swift
.onTapGesture {
    if isAnimated {
        withAnimation(.easeInOut) {
            isExpanded.toggle()
        }
    } else {
         isExpanded.toggle()
    }
}
```

### `ExpandableStyle`

The `Expandable` can be one of three styles:

- `default`: Basic expandable component.
- `box`: Expandable component with a boxed layout. Round corners
- `boxBleed`:  Expandable component with a boxed layout. Square corners

So that calls for an `enum` which we can then also use to control `backgroundColor` and `cornerRadius`

### `ExpandableView`
Is a sandbox view demonstrating how to use the `Expandable` component

## Further Additions
I've taken the liberty of adding a `.navigationTitle` to all demo views...just for similarity 😄 

## That's it!
Yeah, not as complicated as some of the other components so I hope the review is more manageable as well 🤞 

Have fun 😅 