### PR TITLE
Create extension for Warp.Text to change foregroungColor

### DIFF
--- a/Sources/Components/Text/Text.swift
+++ b/Sources/Components/Text/Text.swift
@@ -39,12 +39,11 @@ extension Warp {
     }
 }
 
-public extension Warp.Text {
-    func foregroungColor(_ color: Color) -> Self {
-        return Warp.Text(self.text, style: self.style, color: color)
+extension Warp.Text {
+    public func foregroundColor(_ color: Color) -> Self {
+        return Warp.Text(text, style: style, color: color)
     }
 }
-
 #Preview {
     return ScrollView(showsIndicators: false) {
         ForEach(Warp.TextStyle.allCases, id: \.self) { variant in

--- a/Sources/Components/Text/Text.swift
+++ b/Sources/Components/Text/Text.swift
@@ -39,6 +39,12 @@ extension Warp {
     }
 }
 
+public extension Warp.Text {
+    func foregroungColor(_ color: Color) -> Self {
+        return Warp.Text(self.text, style: self.style, color: color)
+    }
+}
+
 #Preview {
     return ScrollView(showsIndicators: false) {
         ForEach(Warp.TextStyle.allCases, id: \.self) { variant in


### PR DESCRIPTION
We have seen users trying to use the default `.foregroundColor` modifier to change the color of `Warp.Text`, which did not work and it would always be `.textDefault`

So let's fix that