### PR TITLE
Add Tech docs link to Warp-iOS Github readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,22 @@ For detailed setup and component documentation, visit the **[Warp Portal Documen
 
 Explore the following iOS components provided by Warp Design System. Each component links to its detailed documentation for usage, customization, and integration instructions:
 
-- **[Button](https://warp-ds.github.io/tech-docs/components/buttons/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Pill](https://warp-ds.github.io/tech-docs/components/pill/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Checkbox](https://warp-ds.github.io/tech-docs/components/checkbox/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Text Field](https://warp-ds.github.io/tech-docs/components/textfield/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Alert](https://warp-ds.github.io/tech-docs/components/alert/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Steps](https://warp-ds.github.io/tech-docs/components/steps/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Icons](https://warp-ds.github.io/tech-docs/components/icons/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Badge](https://warp-ds.github.io/tech-docs/components/badge/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Box](https://warp-ds.github.io/tech-docs/components/box/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Broadcast](https://warp-ds.github.io/tech-docs/components/broadcast/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Expandable](https://warp-ds.github.io/tech-docs/components/expandable/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Text](https://warp-ds.github.io/tech-docs/components/text/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Toast](https://warp-ds.github.io/tech-docs/components/toast/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Callout](https://warp-ds.github.io/tech-docs/components/callout/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Modal](https://warp-ds.github.io/tech-docs/components/modal/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Spinner](https://warp-ds.github.io/tech-docs/components/spinner/){:target="_blank" rel="noopener noreferrer"}**  
-- **[Tooltip](https://warp-ds.github.io/tech-docs/components/tooltip/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Button](https://warp-ds.github.io/tech-docs/components/buttons/)**  
+- **[Pill](https://warp-ds.github.io/tech-docs/components/pill/)**  
+- **[Checkbox](https://warp-ds.github.io/tech-docs/components/checkbox/)**  
+- **[Text Field](https://warp-ds.github.io/tech-docs/components/textfield/)**  
+- **[Alert](https://warp-ds.github.io/tech-docs/components/alert/)**  
+- **[Steps](https://warp-ds.github.io/tech-docs/components/steps/)**  
+- **[Icons](https://warp-ds.github.io/tech-docs/components/icons/)**  
+- **[Badge](https://warp-ds.github.io/tech-docs/components/badge/)**  
+- **[Box](https://warp-ds.github.io/tech-docs/components/box/)**  
+- **[Broadcast](https://warp-ds.github.io/tech-docs/components/broadcast/)**  
+- **[Expandable](https://warp-ds.github.io/tech-docs/components/expandable/)**  
+- **[Text](https://warp-ds.github.io/tech-docs/components/text/)**  
+- **[Toast](https://warp-ds.github.io/tech-docs/components/toast/)**  
+- **[Callout](https://warp-ds.github.io/tech-docs/components/callout/)**  
+- **[Modal](https://warp-ds.github.io/tech-docs/components/modal/)**  
+- **[Spinner](https://warp-ds.github.io/tech-docs/components/spinner/)**  
+- **[Tooltip](https://warp-ds.github.io/tech-docs/components/tooltip/)**  
 
 

--- a/README.md
+++ b/README.md
@@ -9,102 +9,22 @@ For detailed setup and component documentation, visit the **[Warp Portal Documen
 
 Explore the following iOS components provided by Warp Design System. Each component links to its detailed documentation for usage, customization, and integration instructions:
 
-- **[Button](https://warp-ds.github.io/tech-docs/components/buttons/)**  
-- **[Pill](https://warp-ds.github.io/tech-docs/components/pill/)**  
-- **[Checkbox](https://warp-ds.github.io/tech-docs/components/checkbox/)**  
-- **[Text Field](https://warp-ds.github.io/tech-docs/components/textfield/)**  
-- **[Alert](https://warp-ds.github.io/tech-docs/components/alert/)**  
-- **[Steps](https://warp-ds.github.io/tech-docs/components/steps/)**  
-- **[Icons](https://warp-ds.github.io/tech-docs/components/icons/)**  
-- **[Badge](https://warp-ds.github.io/tech-docs/components/badge/)**  
-- **[Box](https://warp-ds.github.io/tech-docs/components/box/)**  
-- **[Broadcast](https://warp-ds.github.io/tech-docs/components/broadcast/)**  
-- **[Expandable](https://warp-ds.github.io/tech-docs/components/expandable/)**  
-- **[Text](https://warp-ds.github.io/tech-docs/components/text/)**  
-- **[Toast](https://warp-ds.github.io/tech-docs/components/toast/)**  
-- **[Callout](https://warp-ds.github.io/tech-docs/components/callout/)**  
-- **[Modal](https://warp-ds.github.io/tech-docs/components/modal/)**  
-- **[Spinner](https://warp-ds.github.io/tech-docs/components/spinner/)**  
-- **[Tooltip](https://warp-ds.github.io/tech-docs/components/tooltip/)**  
+- **[Button](https://warp-ds.github.io/tech-docs/components/buttons/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Pill](https://warp-ds.github.io/tech-docs/components/pill/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Checkbox](https://warp-ds.github.io/tech-docs/components/checkbox/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Text Field](https://warp-ds.github.io/tech-docs/components/textfield/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Alert](https://warp-ds.github.io/tech-docs/components/alert/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Steps](https://warp-ds.github.io/tech-docs/components/steps/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Icons](https://warp-ds.github.io/tech-docs/components/icons/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Badge](https://warp-ds.github.io/tech-docs/components/badge/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Box](https://warp-ds.github.io/tech-docs/components/box/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Broadcast](https://warp-ds.github.io/tech-docs/components/broadcast/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Expandable](https://warp-ds.github.io/tech-docs/components/expandable/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Text](https://warp-ds.github.io/tech-docs/components/text/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Toast](https://warp-ds.github.io/tech-docs/components/toast/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Callout](https://warp-ds.github.io/tech-docs/components/callout/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Modal](https://warp-ds.github.io/tech-docs/components/modal/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Spinner](https://warp-ds.github.io/tech-docs/components/spinner/){:target="_blank" rel="noopener noreferrer"}**  
+- **[Tooltip](https://warp-ds.github.io/tech-docs/components/tooltip/){:target="_blank" rel="noopener noreferrer"}**  
 
-
-## Getting Started for iOS Developers
-
-This guide describes how to get started building an application using Warp components. If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the **#nmp-warp-design-system** channel on Slack!
-
-### 1. Integrate Warp
-
-To integrate Warp into your project, follow these steps:
-
-#### Swift Package Manager
-
-You can use the Warp URL with Xcode's default package manager or include it in your `Package.swift` file like this:
-
-```swift
-dependencies: [
-    .package(url: "https://github.com/warp-ds/warp-ios.git")
-]
-```
-
-We recommend using the latest version to avoid dependency conflicts. You can specify the version range as follows:
-
-```swift
-dependencies: [
-    .package(url: "https://github.com/warp-ds/warp-ios.git", "0.0.1"..."999.0.0")
-]
-```
-
-### 2. Apply Theme
-
-To start using Warp, initialize the theme based on your selected project target:
-
-```swift
-Warp.Config.warpTheme = .tori
-```
-
-Currently, we support the following themes:
-
-- `.finn` (default)
-- `.tori`
-- `.dba`
-- `.blocket`
-
-### 3. Use Warp Components
-
-Warp components are easy to use with SwiftUI or UIKit. Depending on your selected target, the components will adapt the correct colors and styling.
-
-Example using a Warp button:
-
-```swift
-Warp.Button.create(
-    for: .primary,
-    title: "button",
-    icon: Image(systemName: "plus"),
-    action: {}
-)
-```
-
-### 4. Use Warp Tokens
-
-To ensure brand consistency, we recommend using **Warp Tokens** for colors and styling. Tokens follow categories like `Surface`, `Background`, `Border`, `Icon`, and `Text`.
-
-Avoid using direct colors since they can vary between brands. Instead, use tokens like this:
-
-```swift
-Warp.Text(
-    L10n.ConfirmPersonalData.ConfirmPersonalData.collectioninfo,
-    style: .caption,
-    color: Warp.Token.textSubtle
-)
-```
-
-Still using UIKit? Warp supports it as well with **Warp.UIToken**.
-
-```swift
-private lazy var myView: UIView = {
-    let view = UIView(withAutoLayout: true)
-    view.backgroundColor = Warp.UIToken.background
-    return view
-}()
-```
 

--- a/README.md
+++ b/README.md
@@ -5,26 +5,5 @@ Welcome to the **Warp Design System** for iOS! This repository contains componen
 
 For detailed setup and component documentation, visit the **[Warp Portal Documentation for the Warp Design System](https://warp-ds.github.io/tech-docs/getting-started/ios/)**.
 
-## Components
-
-Explore the following iOS components provided by Warp Design System. Each component links to its detailed documentation for usage, customization, and integration instructions:
-
-- **[Button](https://warp-ds.github.io/tech-docs/components/buttons/)**  
-- **[Pill](https://warp-ds.github.io/tech-docs/components/pill/)**  
-- **[Checkbox](https://warp-ds.github.io/tech-docs/components/checkbox/)**  
-- **[Text Field](https://warp-ds.github.io/tech-docs/components/textfield/)**  
-- **[Alert](https://warp-ds.github.io/tech-docs/components/alert/)**  
-- **[Steps](https://warp-ds.github.io/tech-docs/components/steps/)**  
-- **[Icons](https://warp-ds.github.io/tech-docs/components/icons/)**  
-- **[Badge](https://warp-ds.github.io/tech-docs/components/badge/)**  
-- **[Box](https://warp-ds.github.io/tech-docs/components/box/)**  
-- **[Broadcast](https://warp-ds.github.io/tech-docs/components/broadcast/)**  
-- **[Expandable](https://warp-ds.github.io/tech-docs/components/expandable/)**  
-- **[Text](https://warp-ds.github.io/tech-docs/components/text/)**  
-- **[Toast](https://warp-ds.github.io/tech-docs/components/toast/)**  
-- **[Callout](https://warp-ds.github.io/tech-docs/components/callout/)**  
-- **[Modal](https://warp-ds.github.io/tech-docs/components/modal/)**  
-- **[Spinner](https://warp-ds.github.io/tech-docs/components/spinner/)**  
-- **[Tooltip](https://warp-ds.github.io/tech-docs/components/tooltip/)**  
 
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,110 @@
-# warp-ios
+
+# Warp Design System (iOS)
+
+Welcome to the **Warp Design System** for iOS! This repository contains components and guidelines to help developers build unified, accessible, and visually consistent user interfaces for iOS apps. Warp's design system streamlines the development process while ensuring that all components align with iOS design best practices.
+
+For detailed setup and component documentation, visit the **[Warp Portal Documentation for the Warp Design System](https://warp-ds.github.io/tech-docs/getting-started/ios/)**.
+
+## Components
+
+Explore the following iOS components provided by Warp Design System. Each component links to its detailed documentation for usage, customization, and integration instructions:
+
+- **[Button](https://warp-ds.github.io/tech-docs/components/buttons/)**  
+- **[Pill](https://warp-ds.github.io/tech-docs/components/pill/)**  
+- **[Checkbox](https://warp-ds.github.io/tech-docs/components/checkbox/)**  
+- **[Text Field](https://warp-ds.github.io/tech-docs/components/textfield/)**  
+- **[Alert](https://warp-ds.github.io/tech-docs/components/alert/)**  
+- **[Steps](https://warp-ds.github.io/tech-docs/components/steps/)**  
+- **[Icons](https://warp-ds.github.io/tech-docs/components/icons/)**  
+- **[Badge](https://warp-ds.github.io/tech-docs/components/badge/)**  
+- **[Box](https://warp-ds.github.io/tech-docs/components/box/)**  
+- **[Broadcast](https://warp-ds.github.io/tech-docs/components/broadcast/)**  
+- **[Expandable](https://warp-ds.github.io/tech-docs/components/expandable/)**  
+- **[Text](https://warp-ds.github.io/tech-docs/components/text/)**  
+- **[Toast](https://warp-ds.github.io/tech-docs/components/toast/)**  
+- **[Callout](https://warp-ds.github.io/tech-docs/components/callout/)**  
+- **[Modal](https://warp-ds.github.io/tech-docs/components/modal/)**  
+- **[Spinner](https://warp-ds.github.io/tech-docs/components/spinner/)**  
+- **[Tooltip](https://warp-ds.github.io/tech-docs/components/tooltip/)**  
+
+
+## Getting Started for iOS Developers
+
+This guide describes how to get started building an application using Warp components. If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the **#nmp-warp-design-system** channel on Slack!
+
+### 1. Integrate Warp
+
+To integrate Warp into your project, follow these steps:
+
+#### Swift Package Manager
+
+You can use the Warp URL with Xcode's default package manager or include it in your `Package.swift` file like this:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/warp-ds/warp-ios.git")
+]
+```
+
+We recommend using the latest version to avoid dependency conflicts. You can specify the version range as follows:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/warp-ds/warp-ios.git", "0.0.1"..."999.0.0")
+]
+```
+
+### 2. Apply Theme
+
+To start using Warp, initialize the theme based on your selected project target:
+
+```swift
+Warp.Config.warpTheme = .tori
+```
+
+Currently, we support the following themes:
+
+- `.finn` (default)
+- `.tori`
+- `.dba`
+- `.blocket`
+
+### 3. Use Warp Components
+
+Warp components are easy to use with SwiftUI or UIKit. Depending on your selected target, the components will adapt the correct colors and styling.
+
+Example using a Warp button:
+
+```swift
+Warp.Button.create(
+    for: .primary,
+    title: "button",
+    icon: Image(systemName: "plus"),
+    action: {}
+)
+```
+
+### 4. Use Warp Tokens
+
+To ensure brand consistency, we recommend using **Warp Tokens** for colors and styling. Tokens follow categories like `Surface`, `Background`, `Border`, `Icon`, and `Text`.
+
+Avoid using direct colors since they can vary between brands. Instead, use tokens like this:
+
+```swift
+Warp.Text(
+    L10n.ConfirmPersonalData.ConfirmPersonalData.collectioninfo,
+    style: .caption,
+    color: Warp.Token.textSubtle
+)
+```
+
+Still using UIKit? Warp supports it as well with **Warp.UIToken**.
+
+```swift
+private lazy var myView: UIView = {
+    let view = UIView(withAutoLayout: true)
+    view.backgroundColor = Warp.UIToken.background
+    return view
+}()
+```
+


### PR DESCRIPTION
Updated the README for Warp Design System (iOS) repository
This update includes:

- A new "Getting Started for iOS Developers" section with instructions on integrating Warp components using Swift Package Manager.
- Details on applying themes, using components, and utilizing Warp tokens.
- Links to component-specific documentation on the Warp Portal.

This enhancement aims to provide clear guidance for developers to efficiently integrate and customize Warp in iOS projects.