### PR TITLE
Add public SwiftUI.Image accessor to Warp.Icon

### DIFF
--- a/Sources/Icon/Icon.swift
+++ b/Sources/Icon/Icon.swift
@@ -244,10 +244,17 @@ extension Warp {
         ///
         /// - Returns: A resizable `SwiftUI.Image` instance representing the icon, with a template rendering mode.
         public var body: some View {
+            image
+                .accessibilityLabel(localization)
+        }
+
+        /// Returns a SwiftUI `Image` for the corresponding icon, loaded from the asset catalog.
+        ///
+        /// - Returns: A resizable `SwiftUI.Image` instance representing the icon, with a template rendering mode.
+        public var image: Image {
             SwiftUI.Image(assetName, bundle: .module) // Load the image from the asset catalog
                 .renderingMode(.template) // Ensure template rendering mode for vector images
                 .resizable()
-                .accessibilityLabel(localization)
         }
         
         /// Returns a `UIImage` for the corresponding icon, loaded from the asset catalog.


### PR DESCRIPTION
# Why?

Sometimes one might want to create a `View` that takes an `Image` argument. In order to use Warp icons with such views, we need an `Image` accessor as well.

# What?

Added an accessor to Warp icons so that one can get the corresponding SwiftUI image like `Warp.Icon.someIcon.image`. Have purposefully not touched `BrandIcon` or `TaxonomyIcon` as I don't foresee they have the same needs.

Downside of this is that we lose the accessibility label, but as far as I can tell it's just reading the asset name raw value anyway so it should probably be handled by the user of the icon anyway?