### PR TITLE
[Idea] Add shadow pressed modifier

### DIFF
--- a/SampleApp/Components/ShadowView.swift
+++ b/SampleApp/Components/ShadowView.swift
@@ -21,13 +21,12 @@ struct ShadowView: View {
             }
             .ignoresSafeArea()
             VStack {
-                VStack {
+                Button(action: {}, label: {
                     Warp.Text("surfaceElevated200", style: .caption)
-                }
-                .frame(width: 192, height: 192)
-                .background(colorProvider.token.surfaceElevated200)
-                .cornerRadius(8)
-                .addShadow(shadow)
+                        .frame(width: 192, height: 192)
+                })
+                .buttonStyle(ShadowButtonStyle(shadow: shadow))
+
                 Spacer()
                 Picker("Pick your shadow", selection: $shadow.animation(.interpolatingSpring)) {
                     ForEach(Warp.Shadow.allCases, id: \.self) { shadow in
@@ -40,6 +39,23 @@ struct ShadowView: View {
         }
         .navigationTitle("Shadow")
         .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct ShadowButtonStyle: ButtonStyle {
+    let shadow: Warp.Shadow
+
+    init(shadow: Warp.Shadow) {
+        self.shadow = shadow
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        return configuration.label
+            .background {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Warp.Color.token.surfaceElevated200)
+                    .addShadow(shadow, isPressed: configuration.isPressed)
+            }
     }
 }
 

--- a/SampleApp/Components/ShadowView.swift
+++ b/SampleApp/Components/ShadowView.swift
@@ -4,14 +4,13 @@ import SwiftUI
 struct ShadowView: View {
     private let colorProvider: ColorProvider = Warp.Color
     @State private var shadow = Warp.Shadow.small
-    @State private var isPressed = false
 
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
                 ZStack(alignment: .bottom) {
-                    colorProvider.token.background
-                    Warp.Text("background", style: .caption)
+                    colorProvider.token.surfaceElevated100
+                    Warp.Text("surfaceElevated100", style: .caption)
                         .padding(.bottom)
                 }
                 ZStack(alignment: .top) {
@@ -23,12 +22,12 @@ struct ShadowView: View {
             .ignoresSafeArea()
             VStack {
                 VStack {
-                    Warp.Text(isPressed ? "surfaceElevated200Active" : "surfaceElevated200" , style: .caption)
+                    Warp.Text("surfaceElevated200", style: .caption)
                 }
                 .frame(width: 192, height: 192)
-                .background(isPressed ? colorProvider.token.surfaceElevated200Active : colorProvider.token.surfaceElevated200)
+                .background(colorProvider.token.surfaceElevated200)
                 .cornerRadius(8)
-                .addShadow(shadow, isPressed: $isPressed)
+                .addShadow(shadow)
                 Spacer()
                 Picker("Pick your shadow", selection: $shadow.animation(.interpolatingSpring)) {
                     ForEach(Warp.Shadow.allCases, id: \.self) { shadow in

--- a/SampleApp/Components/ShadowView.swift
+++ b/SampleApp/Components/ShadowView.swift
@@ -4,13 +4,14 @@ import SwiftUI
 struct ShadowView: View {
     private let colorProvider: ColorProvider = Warp.Color
     @State private var shadow = Warp.Shadow.small
+    @State private var isPressed = false
 
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
                 ZStack(alignment: .bottom) {
-                    colorProvider.token.surfaceElevated100
-                    Warp.Text("surfaceElevated100", style: .caption)
+                    colorProvider.token.background
+                    Warp.Text("background", style: .caption)
                         .padding(.bottom)
                 }
                 ZStack(alignment: .top) {
@@ -22,12 +23,12 @@ struct ShadowView: View {
             .ignoresSafeArea()
             VStack {
                 VStack {
-                    Warp.Text("surfaceElevated200", style: .caption)
+                    Warp.Text(isPressed ? "surfaceElevated200Active" : "surfaceElevated200" , style: .caption)
                 }
                 .frame(width: 192, height: 192)
-                .background(colorProvider.token.surfaceElevated200)
+                .background(isPressed ? colorProvider.token.surfaceElevated200Active : colorProvider.token.surfaceElevated200)
                 .cornerRadius(8)
-                .addShadow(shadow)
+                .addShadow(shadow, isPressed: $isPressed)
                 Spacer()
                 Picker("Pick your shadow", selection: $shadow.animation(.interpolatingSpring)) {
                     ForEach(Warp.Shadow.allCases, id: \.self) { shadow in

--- a/Sources/Helpers/View+.swift
+++ b/Sources/Helpers/View+.swift
@@ -32,15 +32,17 @@ extension View {
     /// - Parameters:
     ///   - color: The color to be used for the background. Defaults to `Warp.Token.surfaceElevated200`.
     ///   - cornerRadius: The radius of the rounded corners. Defaults to `Warp.Spacing.spacing200`.
+    ///   - isPressed: A value indicating whether the view is currently in a pressed state and should update its shadow accordingly. Defaults to `false`.
     /// - Returns: A view with the applied card-like background and shadow.
     public func withCardBackground(
         _ color: Color = Warp.Token.surfaceElevated200,
-        cornerRadius: CGFloat = Warp.Spacing.spacing200
+        cornerRadius: CGFloat = Warp.Spacing.spacing200,
+        isPressed: Bool = false
     ) -> some View {
         self.background {
             RoundedRectangle(cornerRadius: cornerRadius)
                 .fill(color)
-                .addShadow(.small)
+                .addShadow(.small, isPressed: isPressed)
         }
     }
     

--- a/Sources/Shadow/Shadow.swift
+++ b/Sources/Shadow/Shadow.swift
@@ -105,7 +105,7 @@ extension Warp {
 /// A view modifier that applies double shadows to a view based on the specified `Warp.Shadow` properties.
 private struct ShadowViewModifier: ViewModifier {
     let shadow: Warp.Shadow
-    let isPressed: Bool
+    @Binding var isPressed: Bool
     
     func body(content: Content) -> some View {
         content
@@ -117,6 +117,15 @@ private struct ShadowViewModifier: ViewModifier {
                     radius: isPressed ? shadow.radius2 * shadow.pressedModifier : shadow.radius2,
                     x: shadow.x2,
                     y: isPressed ? shadow.y2 * shadow.pressedModifier : shadow.y2)
+            .onLongPressGesture(
+                minimumDuration: 0,
+                pressing: { inProgress in
+                    isPressed = inProgress
+                },
+                perform: {
+                    isPressed = false
+                }
+            )
     }
 }
 
@@ -126,7 +135,7 @@ extension View {
     /// - Parameter shadow: A `Warp.Shadow` object containing properties for the two shadows.
     /// - Parameter isPressed: Bool indicating if the shadow should be modified to indicate that view is in a pressed state
     /// - Returns: A view modified with the specified double shadows.
-    public func addShadow(_ shadow: Warp.Shadow, isPressed: Bool = false) -> some View {
+    public func addShadow(_ shadow: Warp.Shadow, isPressed: Binding<Bool> = .constant(false)) -> some View {
         modifier(ShadowViewModifier(shadow: shadow, isPressed: isPressed))
     }
 }

--- a/Sources/Shadow/Shadow.swift
+++ b/Sources/Shadow/Shadow.swift
@@ -89,23 +89,34 @@ extension Warp {
             case .xLarge: return 9
             }
         }
+
+        /// Modifier for offset and radius when view with shadow is in pressed state
+        fileprivate var pressedModifier: CGFloat {
+            switch self {
+            case .small: 0.2
+            case .medium: 0.3
+            case .large: 0.4
+            case .xLarge: 0.7
+            }
+        }
     }
 }
 
 /// A view modifier that applies double shadows to a view based on the specified `Warp.Shadow` properties.
 private struct ShadowViewModifier: ViewModifier {
     let shadow: Warp.Shadow
+    let isPressed: Bool
     
     func body(content: Content) -> some View {
         content
             .shadow(color: .black.opacity(shadow.opacity1),
-                    radius: shadow.radius1,
+                    radius: isPressed ? shadow.radius1 * shadow.pressedModifier : shadow.radius1,
                     x: shadow.x1,
-                    y: shadow.y1)
+                    y: isPressed ? shadow.y1 * shadow.pressedModifier : shadow.y1)
             .shadow(color: .black.opacity(shadow.opacity2),
-                    radius: shadow.radius2,
+                    radius: isPressed ? shadow.radius2 * shadow.pressedModifier : shadow.radius2,
                     x: shadow.x2,
-                    y: shadow.y2)
+                    y: isPressed ? shadow.y2 * shadow.pressedModifier : shadow.y2)
     }
 }
 
@@ -113,9 +124,10 @@ extension View {
     /// Applies double shadows to the view based on the specified `Warp.Shadow` properties.
     ///
     /// - Parameter shadow: A `Warp.Shadow` object containing properties for the two shadows.
+    /// - Parameter isPressed: Bool indicating if the shadow should be modified to indicate that view is in a pressed state
     /// - Returns: A view modified with the specified double shadows.
-    public func addShadow(_ shadow: Warp.Shadow) -> some View {
-        modifier(ShadowViewModifier(shadow: shadow))
+    public func addShadow(_ shadow: Warp.Shadow, isPressed: Bool = false) -> some View {
+        modifier(ShadowViewModifier(shadow: shadow, isPressed: isPressed))
     }
 }
 

--- a/Sources/Shadow/Shadow.swift
+++ b/Sources/Shadow/Shadow.swift
@@ -105,7 +105,7 @@ extension Warp {
 /// A view modifier that applies double shadows to a view based on the specified `Warp.Shadow` properties.
 private struct ShadowViewModifier: ViewModifier {
     let shadow: Warp.Shadow
-    @Binding var isPressed: Bool
+    let isPressed: Bool
     
     func body(content: Content) -> some View {
         content
@@ -117,15 +117,6 @@ private struct ShadowViewModifier: ViewModifier {
                     radius: isPressed ? shadow.radius2 * shadow.pressedModifier : shadow.radius2,
                     x: shadow.x2,
                     y: isPressed ? shadow.y2 * shadow.pressedModifier : shadow.y2)
-            .onLongPressGesture(
-                minimumDuration: 0,
-                pressing: { inProgress in
-                    isPressed = inProgress
-                },
-                perform: {
-                    isPressed = false
-                }
-            )
     }
 }
 
@@ -135,7 +126,7 @@ extension View {
     /// - Parameter shadow: A `Warp.Shadow` object containing properties for the two shadows.
     /// - Parameter isPressed: Bool indicating if the shadow should be modified to indicate that view is in a pressed state
     /// - Returns: A view modified with the specified double shadows.
-    public func addShadow(_ shadow: Warp.Shadow, isPressed: Binding<Bool> = .constant(false)) -> some View {
+    public func addShadow(_ shadow: Warp.Shadow, isPressed: Bool = false) -> some View {
         modifier(ShadowViewModifier(shadow: shadow, isPressed: isPressed))
     }
 }


### PR DESCRIPTION
# Why?

When we add shadows to tappable views, i.e. a card view, it makes intuitive sense for there to be some form of shadow interaction when pressing. 
One quick way to achieve something like this is as a user of Warp is by changing which shadow is used (`.addShadow(isPressed ? .small : .medium`), but then there's no option if the initial shadow was small.

# What? 

An `isPressed` bool that can be passed to the `ShadowViewModifier` through `addShadow(_ shadow:isPressed:)`. Passing true causes modification of shadow offset and radius. The current modifiers are kind of arbitrary, but they serve to illustrate the idea.

# What does it look like?
https://github.com/user-attachments/assets/1905ea0f-814b-41ce-8bd6-2cb8d8cc5432