### PR TITLE
Improvement: set `TokenProvider` and `UITokenProvider` when the `Theme` is updated

### DIFF
--- a/Sources/Typography/Typography+Register.swift
+++ b/Sources/Typography/Typography+Register.swift
@@ -30,13 +30,22 @@ extension Warp.Typography {
             throw Warp.FontRegistrationError.unableToFindFont(name: fontName)
         }
         
-        // Attempt to register the font with Core Text
-        var error: Unmanaged<CFError>?
-        let isSuccessful = CTFontManagerRegisterFontsForURL(fontURL as CFURL, .process, &error)
+        let isFontAlreadyRegistered = UIFont.familyNames.contains(where: { family in
+            UIFont.fontNames(forFamilyName: family).contains(fontName)
+        })
         
-        // If registration fails, throw an error
-        if !isSuccessful {
-            throw Warp.FontRegistrationError.unableToRegisterFont(error: error?.takeUnretainedValue())
+        // Register the font only if it has not been registered from before
+        guard isFontAlreadyRegistered == true else {
+            // Attempt to register the font with Core Text
+            var error: Unmanaged<CFError>?
+            let isSuccessful = CTFontManagerRegisterFontsForURL(fontURL as CFURL, .process, &error)
+            
+            // If registration fails, throw an error
+            if !isSuccessful {
+                throw Warp.FontRegistrationError.unableToRegisterFont(error: error?.takeUnretainedValue())
+            }
+
+            return
         }
     }
 }

--- a/Sources/Warp.swift
+++ b/Sources/Warp.swift
@@ -6,7 +6,7 @@ public enum Warp {
     // MARK: - Brand Enum
 
     /// Enumeration representing different brands supported by the Warp design system.
-    public enum Brand: CustomStringConvertible {
+    public enum Brand: CustomStringConvertible, CaseIterable {
         /// Represents the `Finn` brand theme.
         case finn
         /// Represents the `Tori` brand theme.

--- a/Sources/Warp.swift
+++ b/Sources/Warp.swift
@@ -55,7 +55,7 @@ public enum Warp {
     ///
     /// This computed property returns an instance of a token provider specific to the currently set theme.
     /// The token provider defines color tokens used throughout the application.
-    public static var Token: TokenProvider = {
+    public static var Token: TokenProvider {
         switch Theme {
         case .finn:
             return FinnTokenProvider()
@@ -66,13 +66,13 @@ public enum Warp {
         case .blocket:
             return BlocketTokenProvider()
         }
-    }()
+    }
     
     /// Provides UIToken values based on the current theme.
     ///
     /// This computed property returns an instance of a UIToken provider specific to the currently set theme.
     /// The token provider defines UIColor tokens used throughout the application.
-    public static var UIToken: UITokenProvider = {
+    public static var UIToken: UITokenProvider {
         switch Theme {
         case .finn:
             return FinnUITokenProvider()
@@ -83,7 +83,7 @@ public enum Warp {
         case .blocket:
             return BlocketUITokenProvider()
         }
-    }()
+    }
     
     // MARK: - Color Providers
 
@@ -91,17 +91,17 @@ public enum Warp {
     ///
     /// This computed property returns an instance of a `ColorProvider` initialized with the current theme tokens.
     /// It facilitates easy access to brand-specific colors that are used throughout the design system.
-    public static var Color: ColorProvider = {
+    public static var Color: ColorProvider {
         ColorProvider(token: Warp.Token)
-    }()
+    }
     
     /// Provides `UIColor` values based on the current theme UITokens.
     ///
     /// This computed property returns an instance of a `UIColorProvider` initialized with the current theme UITokens.
     /// It facilitates easy access to brand-specific UIColors that are used throughout the design system.
-    public static var UIColor: UIColorProvider = {
+    public static var UIColor: UIColorProvider {
         UIColorProvider(token: Warp.UIToken)
-    }()
+    }
 
     // MARK: - Dataviz Token Providers
 
@@ -109,15 +109,15 @@ public enum Warp {
     ///
     /// This computed property returns an instance of a `DatavizTokenProvider`.
     /// It facilitates easy access to dataviz colors that are used throughout the design system.
-    public static var DatavizToken = {
+    public static var DatavizToken: DatavizTokenProvider {
         DatavizTokenProvider()
-    }()
+    }
 
     /// Provides `UIColor` values for Dataviz tokens.
     ///
     /// This computed property returns an instance of a `DatavizUITokenProvider`.
     /// It facilitates easy access to dataviz colors that are used throughout the design system.
-    public static var DatavizUIToken = {
+    public static var DatavizUIToken: DatavizUITokenProvider {
         DatavizUITokenProvider()
-    }()
+    }
 }

--- a/Sources/Warp.swift
+++ b/Sources/Warp.swift
@@ -6,7 +6,7 @@ public enum Warp {
     // MARK: - Brand Enum
 
     /// Enumeration representing different brands supported by the Warp design system.
-    public enum Brand {
+    public enum Brand: CustomStringConvertible {
         /// Represents the `Finn` brand theme.
         case finn
         /// Represents the `Tori` brand theme.
@@ -15,6 +15,19 @@ public enum Warp {
         case dba
         /// Represents the `Blocket` brand theme.
         case blocket
+
+        public var description: String {
+            switch self {
+            case .finn:
+                return "FINN"
+            case .tori:
+                return "Tori"
+            case .dba:
+                return "DBA"
+            case .blocket:
+                return "Blocket"
+            }
+        }
     }
     
     // MARK: - Theme Property


### PR DESCRIPTION
# Why?
- Previously, changing the `Theme` property between test runs did not reliably update associated colors and tokens, leading to incorrect themes being applied when snapshot tests ran in parallel. 

# What?

- Change the properties: `Token`, `UIToken`, `Color`, `UIColor`, `DatavizToken` and `DatavizUIToken` from `stored` properties to `computed` properties. These properties will be re-computed whenever the `Theme` property is changed rather than computed and stored once.

- Validate that the font has not been registered before registering it.

- Make `Theme` property conform to `CustomStringConvertible` and `CaseIterable` in order to use it as a parameter that we can pass to the parameterised tests provided from the `Swift Testing` framework.