### PR TITLE
fix: Include isEnabled in equality check

### DIFF
--- a/Sources/Components/Button/Button.swift
+++ b/Sources/Components/Button/Button.swift
@@ -38,7 +38,9 @@ extension Warp {
             lhs.title == rhs.title &&
             lhs.type == rhs.type &&
             lhs.size == rhs.size &&
-            lhs.isEnabled == rhs.isEnabled
+            lhs.isEnabled == rhs.isEnabled &&
+            lhs.isLoading == rhs.isLoading &&
+            lhs.fullWidth == rhs.fullWidth
         }
 
         public func hash(into hasher: inout Hasher) {
@@ -46,6 +48,8 @@ extension Warp {
             hasher.combine(type)
             hasher.combine(size)
             hasher.combine(isEnabled)
+            hasher.combine(isLoading)
+            hasher.combine(fullWidth)
         }
 
         public init(

--- a/Sources/Components/Button/Button.swift
+++ b/Sources/Components/Button/Button.swift
@@ -37,13 +37,15 @@ extension Warp {
         public static func == (lhs: Button, rhs: Button) -> Bool {
             lhs.title == rhs.title &&
             lhs.type == rhs.type &&
-            lhs.size == rhs.size
+            lhs.size == rhs.size &&
+            lhs.isEnabled == rhs.isEnabled
         }
 
         public func hash(into hasher: inout Hasher) {
             hasher.combine(title)
             hasher.combine(type)
             hasher.combine(size)
+            hasher.combine(isEnabled)
         }
 
         public init(


### PR DESCRIPTION
I have a `Warp.Button` where I toggle the `isEnabled` depending on whether entries in a user form is correct or not.

Today I noticed that this had stopped working.

After _many_ tries and much general confusion I was able to narrow it down to being a bug (feature?) being introduced with version 0.0.51 of Warp.

I can see that the only new thing added to `Warp.Button` is `Hashable` conformance and with that a static `==` function.

This seems to break my `isEnabled` logic. I guess because the `==` function doesn't use `isEnabled` to determine if two buttons are equal.

I've therefore added `isEnabled` to the `==` and `hash` functions.

🤔 And I'm not sure if we need to add more parameters to those checks (`isLoading` maybe?)


## Important!
**This fix is kinda important since version 0.0.51 of the library breaks the KYC flow!**

Are we ready to bump to a new version 0.0.53 with this fix or should we patch 0.0.51 and hold 0.0.52 back?