### PR TITLE
Add scrollable parameter to Tabs component

### DIFF
--- a/SampleApp/Components/TabsView.swift
+++ b/SampleApp/Components/TabsView.swift
@@ -3,6 +3,7 @@ import Warp
 
 struct TabsView: View {
     @State private var hasIcons = true
+    @State private var isScrollable = true
     @State private var selectedIndex: Int = 0
     private let tabItems: [Warp.TabItem] = [
         Warp.TabItem(title: "Tab 1", icon: .listSort),
@@ -13,20 +14,30 @@ struct TabsView: View {
     
     var body: some View {
         VStack {
-            Warp.Tabs(tabs: tabItems.map { hasIcons ? $0 : .init(title: $0.title) }, selectedIndex: $selectedIndex)
-            
-            // Controls to toggle icon visibility in tabs
+            Warp.Tabs(
+                tabs: tabItems.map { hasIcons ? $0 : .init(title: $0.title) },
+                selectedIndex: $selectedIndex,
+                scrollable: isScrollable
+            )
+
+            // Controls to toggle tab appearance and behaviour
             GroupBox {
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: 16) {
                     HStack {
                         Text("Show Icon")
                         Spacer()
                         Warp.Switch(isOn: $hasIcons)
                     }
-                    .padding(.top, 20)
+
+                    HStack {
+                        Text("Scrollable")
+                        Spacer()
+                        Warp.Switch(isOn: $isScrollable)
+                    }
                 }
+                .padding(.vertical, 16)
             } label: {
-                Text("Modify Tabs Icon")
+                Text("Modify Tabs")
             }
         }
         .onChange(of: selectedIndex) { _ in

--- a/Sources/Components/Tabs/Tabs.swift
+++ b/Sources/Components/Tabs/Tabs.swift
@@ -8,9 +8,11 @@ extension Warp {
     /// - Parameters:
     ///   - tabs: An array of `TabItem` objects, each containing a title and an optional icon to display in the tab.
     ///   - selectedIndex: A binding to the index of the currently selected tab.
+    ///   - scrollable: A boolean value indicating whether the tabs should be scrollable. Non-scrollable tabs will grow in size to fill the width of the parent view.
     public struct Tabs: View {
         public let tabs: [TabItem]
         @Binding private var selectedIndex: Int
+        private let isScrollable: Bool
         private let colorProvider: ColorProvider = Warp.Color
         
         /// Initializes the Tabs view with an array of tabs and a binding for the selected index.
@@ -18,42 +20,28 @@ extension Warp {
         /// - Parameters:
         ///   - tabs: An array of `TabItem` objects to display as selectable tabs.
         ///   - selectedIndex: A binding to the index of the currently selected tab. Updates to this binding will be observed by the view, triggering animations and layout changes.
-        public init(tabs: [TabItem], selectedIndex: Binding<Int>) {
+        ///   - scrollable: A boolean value indicating whether the tabs should be scrollable. Defaults to `true`.
+        public init(
+            tabs: [TabItem],
+            selectedIndex: Binding<Int>,
+            scrollable: Bool = true
+        ) {
             self.tabs = tabs
             self._selectedIndex = selectedIndex
+            self.isScrollable = scrollable
         }
         
         public var body: some View {
             VStack(spacing: 0) {
-                ScrollViewReader { scrollProxy in
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(alignment: .center, spacing: 0) {
-                            ForEach(tabs.indices, id: \.self) { index in
-                                let tab = tabs[index]
-                                VStack(spacing: 8) {
-                                    // Display tab content
-                                    TabItemView(
-                                        title: tab.title,
-                                        icon: tab.icon,
-                                        isSelected: index == selectedIndex
-                                    )
-                                    .onTapGesture {
-                                        withAnimation(.easeInOut(duration: 0.3)) {
-                                            selectedIndex = index
-                                            scrollProxy.scrollTo(index, anchor: .center)
-                                        }
-                                    }
-                                    .offset(y: index == selectedIndex ? 1.5 : 0)
-                                    
-                                    // Draw underline based on selection
-                                    Rectangle()
-                                        .fill(index == selectedIndex ? colorProvider.token.borderSelected : colorProvider.token.border)
-                                        .frame(height: index == selectedIndex ? 3 : 0)
-                                        .offset(y: index == selectedIndex ? -1.5 : 0)
-                                        .animation(.easeInOut(duration: 0.3), value: selectedIndex)
-                                }
+                Group {
+                    if isScrollable {
+                        ScrollViewReader { scrollProxy in
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                tabsView(scrollProxy: scrollProxy)
                             }
                         }
+                    } else {
+                        tabsView(scrollProxy: nil)
                     }
                 }
                 .background(
@@ -70,14 +58,63 @@ extension Warp {
                 )
             }
         }
+
+        private func tabsView(scrollProxy: ScrollViewProxy?) -> some View {
+            HStack(alignment: .center, spacing: 0) {
+                ForEach(tabs.indices, id: \.self) { index in
+                    let tab = tabs[index]
+                    VStack(spacing: 8) {
+                        // Display tab content
+                        TabItemView(
+                            title: tab.title,
+                            icon: tab.icon,
+                            isSelected: index == selectedIndex
+                        )
+                        .onTapGesture {
+                            withAnimation(.easeInOut(duration: 0.3)) {
+                                selectedIndex = index
+                                scrollProxy?.scrollTo(index, anchor: .center)
+                            }
+                        }
+                        .offset(y: index == selectedIndex ? 1.5 : 0)
+
+                        // Draw underline based on selection
+                        Rectangle()
+                            .fill(index == selectedIndex ? colorProvider.token.borderSelected : colorProvider.token.border)
+                            .frame(height: index == selectedIndex ? 3 : 0)
+                            .offset(y: index == selectedIndex ? -1.5 : 0)
+                            .animation(.easeInOut(duration: 0.3), value: selectedIndex)
+                    }
+                }
+            }
+        }
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    Warp.Tabs(tabs: [
-        Warp.TabItem(title: "Tab 1", icon: .listSort),
-        Warp.TabItem(title: "Longer Tab Title", icon: .listSort),
-        Warp.TabItem(title: "Tab 3", icon: .listSort),
-        Warp.TabItem(title: "Tab 4", icon: .listSort)
-    ], selectedIndex: .constant(0))
+    @Previewable @State var selectedIndex1 = 0
+    @Previewable @State var selectedIndex2 = 0
+
+    VStack(spacing: 40) {
+        Warp.Tabs(
+            tabs: [
+                Warp.TabItem(title: "Tab 1", icon: .listSort),
+                Warp.TabItem(title: "Longer Tab Title", icon: .listSort),
+                Warp.TabItem(title: "Tab 3", icon: .listSort),
+                Warp.TabItem(title: "Tab 4", icon: .listSort)
+            ],
+            selectedIndex: $selectedIndex1,
+            scrollable: true
+        )
+
+        Warp.Tabs(
+            tabs: [
+                Warp.TabItem(title: "Tab 1", icon: .listSort),
+                Warp.TabItem(title: "Tab 2", icon: .listSort)
+            ],
+            selectedIndex: $selectedIndex2,
+            scrollable: false
+        )
+    }
 }


### PR DESCRIPTION
# Why? 

We want to be able to create screens with just two tabs with the tabs taking up the full width of the screen regardless of text length.

# What?

Add a parameter `scrollable` to the `Tabs` component which if set to `false` neglects the `ScrollView` and makes the tabs take up the available horizontal space instead. 

### Note
This change does not handle long text lengths or changes to text size due to dynamic type. The existing view doesn't really handle dynamic type well either, so I'm not sure I'd consider this a flaw of this PR in particular.

# Screenshot

<img width="355" alt="Screenshot 2025-03-22 at 14 43 59" src="https://github.com/user-attachments/assets/d8e33915-f7e8-436f-9ee8-5488974982f2" />
