### PR TITLE
Remove vertical padding for default styled expandable view

### DIFF
--- a/Sources/Components/Expandable/Expandable.swift
+++ b/Sources/Components/Expandable/Expandable.swift
@@ -59,8 +59,7 @@ extension Warp {
                 }
             }
             .frame(maxWidth: .infinity)
-            .padding(.vertical, Warp.Spacing.spacing200)
-            .padding(.horizontal, style == .default ? 0 : Warp.Spacing.spacing200)
+            .padding(style == .default ? 0 : Warp.Spacing.spacing200)
             .background(style.backgroundColor(using: colorProvider))
             .cornerRadius(style.cornerRadius)
         }


### PR DESCRIPTION
# Why? 

If one puts a `default` styled expandable view in a `VStack` with some spacing, this spacing compounds with the padding on the expandable view making it look weirdly misaligned compared to every other view in the stack.

# What?

Don't add vertical padding for the `default` style.

|Before|After|
| --- | --- |
|<img width="350" alt="Screenshot 2025-03-24 at 10 12 19" src="https://github.com/user-attachments/assets/c98ba007-8b28-4889-bb46-103e58698590" />|<img width="350" alt="Screenshot 2025-03-24 at 10 11 38" src="https://github.com/user-attachments/assets/e7f5a555-a2a8-44b0-a64e-81a2f3ae934d" />|


