### PR TITLE
Add theme preview modifier

### DIFF
--- a/Sources/Previews/ThemePreviewModifier.swift
+++ b/Sources/Previews/ThemePreviewModifier.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-/// A preview modifier that sets the Warp theme.
+/// A preview modifier that sets the Warp theme in the preview.
 ///
-/// Use like #Preview(traits: .themeFinn)
+/// Usage: `#Preview(traits: .themeFinn)`
 public struct ThemePreviewModifier: PreviewModifier {
     init(theme: Warp.Brand) {
         Warp.Theme = theme
@@ -17,8 +17,15 @@ public struct ThemePreviewModifier: PreviewModifier {
 
 @available(iOS 18.0, *)
 public extension PreviewTrait where T == Preview.ViewTraits {
+    /// Preview modifier that sets the Blocket Warp theme.
     static let themeBlocket = PreviewTrait.modifier(ThemePreviewModifier(theme: .blocket))
+
+    /// Preview modifier that sets the DBA Warp theme.
     static let themeDba = PreviewTrait.modifier(ThemePreviewModifier(theme: .dba))
+
+    /// Preview modifier that sets the FINN Warp theme.
     static let themeFinn = PreviewTrait.modifier(ThemePreviewModifier(theme: .finn))
+
+    /// Preview modifier that sets the Tori Warp theme.
     static let themeTori = PreviewTrait.modifier(ThemePreviewModifier(theme: .tori))
 }

--- a/Sources/Previews/ThemePreviewModifier.swift
+++ b/Sources/Previews/ThemePreviewModifier.swift
@@ -3,14 +3,14 @@ import SwiftUI
 /// A preview modifier that sets the Warp theme in the preview.
 ///
 /// Usage: `#Preview(traits: .themeFinn)`
-public struct ThemePreviewModifier: PreviewModifier {
+struct ThemePreviewModifier: PreviewModifier {
     init(theme: Warp.Brand) {
         Warp.Theme = theme
     }
 
-    public static func makeSharedContext() async throws -> Void {}
+    static func makeSharedContext() async throws -> Void {}
 
-    public func body(content: Content, context: Void) -> some View {
+    func body(content: Content, context: Void) -> some View {
         content
     }
  }

--- a/Sources/Previews/ThemePreviewModifier.swift
+++ b/Sources/Previews/ThemePreviewModifier.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// A preview modifier that sets the Warp theme.
+///
+/// Use like #Preview(traits: .themeFinn)
+public struct ThemePreviewModifier: PreviewModifier {
+    init(theme: Warp.Brand) {
+        Warp.Theme = theme
+    }
+
+    public static func makeSharedContext() async throws -> Void {}
+
+    public func body(content: Content, context: Void) -> some View {
+        content
+    }
+ }
+
+@available(iOS 18.0, *)
+public extension PreviewTrait where T == Preview.ViewTraits {
+    static let themeBlocket = PreviewTrait.modifier(ThemePreviewModifier(theme: .blocket))
+    static let themeDba = PreviewTrait.modifier(ThemePreviewModifier(theme: .dba))
+    static let themeFinn = PreviewTrait.modifier(ThemePreviewModifier(theme: .finn))
+    static let themeTori = PreviewTrait.modifier(ThemePreviewModifier(theme: .tori))
+}


### PR DESCRIPTION
# Why?

Xcode previews in the SMP project look wrong because Warp theme is not set

# What?

Add a preview modifier that lets us set the theme like:
```swift
@available(iOS 18.0, *)
#Preview(traits: .themeFinn) {
    MyWarpReliantView()
}
```