### PR TITLE
Add content shape to tab item

### DIFF
--- a/Sources/Components/Tabs/TabItem.swift
+++ b/Sources/Components/Tabs/TabItem.swift
@@ -24,19 +24,18 @@ extension Warp {
         private let colorProvider: ColorProvider = Warp.Color
         
         public var body: some View {
-            VStack {
-                HStack(alignment: .center, spacing: Warp.Spacing.spacing100) {
-                    if let icon = icon {
-                        Warp.IconView(icon, size: .small)
-                            .foregroundColor(isSelected ? colorProvider.token.textLink : colorProvider.token.textSubtle)
-                    }
-                    SwiftUI.Text(title)
-                        .font(from: .bodyStrong)
+            HStack(alignment: .center, spacing: Warp.Spacing.spacing100) {
+                if let icon = icon {
+                    Warp.IconView(icon, size: .small)
                         .foregroundColor(isSelected ? colorProvider.token.textLink : colorProvider.token.textSubtle)
-                        .lineLimit(1)
                 }
-                .padding(.horizontal, Warp.Spacing.spacing200)
+                SwiftUI.Text(title)
+                    .font(from: .bodyStrong)
+                    .foregroundColor(isSelected ? colorProvider.token.textLink : colorProvider.token.textSubtle)
+                    .lineLimit(1)
             }
+            .padding(.horizontal, Warp.Spacing.spacing200)
+            .contentShape(Rectangle())
         }
     }
 }


### PR DESCRIPTION
# Why?

If the tab item is wider than its text, the area outside of the text does not respond to taps

# What?

Give the tab item a content shape. Also remove a wrapping VStack which seemed superfluous.