### PR TITLE
Make CheckBox title optional

### DIFF
--- a/Sources/Components/Checkbox/Checkbox.swift
+++ b/Sources/Components/Checkbox/Checkbox.swift
@@ -35,7 +35,7 @@ extension Warp {
         ///   - extraContent: An optional view that will be displayed beside the label.
         ///   - action: A closure that is executed when the checkbox is tapped.
         public init(isSelected: Binding<Bool>,
-                    label: String? = nil,
+                    label: String,
                     style: CheckboxStyle = .default,
                     extraContent: AnyView? = nil,
                     action: @escaping () -> Void) {
@@ -45,7 +45,21 @@ extension Warp {
             self.extraContent = extraContent
             self.action = action
         }
-        
+
+        /// Initializes a new `Checkbox` without title and extra content.
+        ///
+        /// - Parameters:
+        ///   - isSelected: A `Binding` value indicating whether the checkbox button is selected.
+        ///   - style: The style the checkbox can have (default, error, disabled).
+        public init(isSelected: Binding<Bool>,
+                    style: CheckboxStyle = .default) {
+            self._isSelected = isSelected
+            self.label = nil
+            self.style = style
+            self.extraContent = nil
+            self.action = { }
+        }
+
         public var body: some View {
             HStack(alignment: .top, spacing: Spacing.spacing100) {
                 Image(iconName, bundle: .module)

--- a/Sources/Components/Checkbox/Checkbox.swift
+++ b/Sources/Components/Checkbox/Checkbox.swift
@@ -15,8 +15,8 @@ extension Warp {
     public struct Checkbox: View {
         /// A `Binding` value indicating whether the checkbox button is selected.
         @Binding var isSelected: Bool
-        /// The text label for the checkbox.
-        var label: String
+        /// The optional text label for the checkbox.
+        var label: String?
         /// The style the checkbox can have (default, error, disabled).
         var style: CheckboxStyle
         /// An optional view that will be displayed beside the label.
@@ -35,7 +35,7 @@ extension Warp {
         ///   - extraContent: An optional view that will be displayed beside the label.
         ///   - action: A closure that is executed when the checkbox is tapped.
         public init(isSelected: Binding<Bool>,
-                    label: String,
+                    label: String?,
                     style: CheckboxStyle = .default,
                     extraContent: AnyView? = nil,
                     action: @escaping () -> Void) {
@@ -55,10 +55,10 @@ extension Warp {
                     .frame(width: 20, height: 20)
                     .background(backgroundColor.cornerRadius(4))
                     .animation(.interpolatingSpring())
-                
-                contentStack
-                
-                Spacer()
+
+                if label != nil || extraContent != nil {
+                    contentStack
+                }
             }
             .onTapGesture {
                 if style != .disabled {
@@ -70,9 +70,11 @@ extension Warp {
         @ViewBuilder
         private var contentStack: some View {
             HStack(alignment: .top, spacing: Spacing.spacing100) {
-                SwiftUI.Text(label)
-                    .font(from: .body)
-                    .foregroundColor(textColor)
+                if let label {
+                    SwiftUI.Text(label)
+                        .font(from: .body)
+                        .foregroundColor(textColor)
+                }
                 if let extraContent = extraContent {
                     extraContent
                 }
@@ -105,7 +107,7 @@ extension Warp {
             case .default, .error:
                 return colorProvider.token.background
             case .disabled:
-                return colorProvider.token.backgroundDisabledSubtle
+                return colorProvider.token.textInverted
             }
         }
         

--- a/Sources/Components/Checkbox/Checkbox.swift
+++ b/Sources/Components/Checkbox/Checkbox.swift
@@ -35,7 +35,7 @@ extension Warp {
         ///   - extraContent: An optional view that will be displayed beside the label.
         ///   - action: A closure that is executed when the checkbox is tapped.
         public init(isSelected: Binding<Bool>,
-                    label: String?,
+                    label: String? = nil,
                     style: CheckboxStyle = .default,
                     extraContent: AnyView? = nil,
                     action: @escaping () -> Void) {

--- a/Sources/Components/Checkbox/Checkbox.swift
+++ b/Sources/Components/Checkbox/Checkbox.swift
@@ -35,29 +35,15 @@ extension Warp {
         ///   - extraContent: An optional view that will be displayed beside the label.
         ///   - action: A closure that is executed when the checkbox is tapped.
         public init(isSelected: Binding<Bool>,
-                    label: String,
+                    label: String? = nil,
                     style: CheckboxStyle = .default,
                     extraContent: AnyView? = nil,
-                    action: @escaping () -> Void) {
+                    action: @escaping () -> Void = {}) {
             self._isSelected = isSelected
             self.label = label
             self.style = style
             self.extraContent = extraContent
             self.action = action
-        }
-
-        /// Initializes a new `Checkbox` without title and extra content.
-        ///
-        /// - Parameters:
-        ///   - isSelected: A `Binding` value indicating whether the checkbox button is selected.
-        ///   - style: The style the checkbox can have (default, error, disabled).
-        public init(isSelected: Binding<Bool>,
-                    style: CheckboxStyle = .default) {
-            self._isSelected = isSelected
-            self.label = nil
-            self.style = style
-            self.extraContent = nil
-            self.action = { }
         }
 
         public var body: some View {


### PR DESCRIPTION
# Why, What, How

There's a new component in TJT and I wanted to use the check box from Warp to conform to the unified design principles. At the moment it always requires a title and setting and empty `String` would not result in an optimal layout.

In this PR I made the title optional and set `nil` as a default value. This won't break the current implementations.

| Before | After |
| --- | --- |
| <img width="400" alt="Screenshot 2025-05-12 at 16 55 54" src="https://github.com/user-attachments/assets/71ddcddf-8d89-4908-b2c5-8435ff8994f1" /> | <img width="400" alt="Screenshot 2025-05-12 at 16 56 14" src="https://github.com/user-attachments/assets/ca9181b6-f974-497e-854a-a30b470605f9" /> |

As you can see on the screenshots the view boundaries are looking cleaner.

# A small detail

Having shown the disabled state I noticed that the checkmark color is barely visible so I set a more noticeable one.

| Before | After |
| --- | --- |
| ![Screenshot 2025-05-13 at 10 28 38](https://github.com/user-attachments/assets/63d1f57a-23b4-49fb-96e0-a6289b9d25ff) | ![Screenshot 2025-05-13 at 10 29 10](https://github.com/user-attachments/assets/c29e129d-b73d-444d-9c7f-8bb84f771c93) |

