### PR TITLE
Add `duration` parameter to `Toast` component

### DIFF
--- a/Sources/Components/Toast/Toast.swift
+++ b/Sources/Components/Toast/Toast.swift
@@ -28,6 +28,9 @@ extension Warp {
         /// Edge from where the toast is presented
         let toastEdge: Warp.ToastEdge
 
+        /// Duration for which the toast will be displayed
+        let duration: Duration
+
         /// Binding to a boolean value that allows the toast to control dismissal
         @Binding public var isPresented: Bool
 
@@ -38,17 +41,20 @@ extension Warp {
          - Parameter style: The `ToastStyle` of the `Toast`
          - Parameter title: String to display in the `Toast`
          - Parameter toastEdge: The `ToastEdge` on where to present the `Toast`
+         - Parameter duration: Duration for which the `Toast` will be displayed, default is `.short`
          - Parameter isPresented: Is the `Toast` presented or not
          */
         public init(
             style: Warp.ToastStyle,
             title: String,
             toastEdge: Warp.ToastEdge,
+            duration: Duration = .short,
             isPresented: Binding<Bool>
         ) {
             self.style = style
             self.title = title
             self.toastEdge = toastEdge
+            self.duration = duration
             self._isPresented = isPresented
         }
 
@@ -58,10 +64,16 @@ extension Warp {
                 RoundedRectangle(cornerRadius: toastCornerRadius)
                     .stroke(style.subtleBorderColor(from: colorProvider), lineWidth: 4)
             )
-            .frame(maxWidth: .infinity)
+            .frame(maxWidth: 420)
             .background(style.backgroundColor(from: colorProvider))
             .cornerRadius(toastCornerRadius)
             .transition(AnyTransition.move(edge: toastEdge.asEdge).combined(with: .opacity))
+            .task {
+                do {
+                    try await Task.sleep(nanoseconds: duration.timeInNanoseconds)
+                    isPresented.toggle()
+                } catch {} // Handle cancellation if needed
+            }
             .onTapGesture {
                 withAnimation {
                     isPresented.toggle()

--- a/Sources/Components/Toast/ToastDuration.swift
+++ b/Sources/Components/Toast/ToastDuration.swift
@@ -1,0 +1,35 @@
+//
+// Created by Łukasz Śliwa on 18/07/2025.
+//
+
+import SwiftUI
+
+extension Warp.Toast {
+
+    /// Enum representing defined duration of a toast message.
+    public enum Duration {
+        /// Short duration, typically used for quick feedback messages.
+        /// Default is 5 seconds.
+        case short
+        /// Long duration, typically used for more significant messages that require user attention.
+        /// Default is 10 seconds.
+        case long
+        /// Infinite duration, typically used for messages that require user interaction to dismiss.
+        case infinite
+        /// Custom duration time interval
+        case custom(interval: TimeInterval)
+
+        var timeInNanoseconds: UInt64 {
+            switch self {
+            case .short:
+                5_000_000_000 // 5 seconds
+            case .long:
+                10_000_000_000 // 10 seconds
+            case .infinite:
+                6_000_000_000_000
+            case .custom(let interval):
+                UInt64(interval * 1_000_000_000) // Convert time interval to nanoseconds
+            }
+        }
+    }
+}

--- a/Sources/Components/Toast/ToastViewModifier.swift
+++ b/Sources/Components/Toast/ToastViewModifier.swift
@@ -5,6 +5,7 @@ extension Warp {
         let style: Warp.ToastStyle
         let title: String
         let edge: ToastEdge
+        let duration: Toast.Duration
         private let horizontalPadding: Double = 16
         @Binding var isPresented: Bool
 
@@ -25,6 +26,7 @@ extension Warp {
                     style: style,
                     title: title,
                     toastEdge: edge,
+                    duration: duration,
                     isPresented: $isPresented
                 )
                 .padding(.horizontal, horizontalPadding)
@@ -39,6 +41,7 @@ public extension View {
         style: Warp.ToastStyle,
         title: String,
         edge: Warp.ToastEdge,
+        duration: Warp.Toast.Duration = .short,
         isPresented: Binding<Bool>
     ) -> some View {
         self.modifier(
@@ -46,6 +49,7 @@ public extension View {
                 style: style,
                 title: title,
                 edge: edge,
+                duration: duration,
                 isPresented: isPresented
             )
         )

--- a/Tests/tests/ToastTests/ToastTests.swift
+++ b/Tests/tests/ToastTests/ToastTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import SwiftUI
+@testable import Warp
+
+@Suite
+struct ToastTests {
+
+    @available(iOS 16.0, *)
+    @Test @MainActor
+    func testToastShouldAutomaticallyDisappear() async throws {
+        let dissapearAfterTime: TimeInterval = 0.3
+        let waitingTime: TimeInterval = dissapearAfterTime + 0.1
+
+        var isPresented = true
+        let toast = EmptyView()
+            .warpToast(
+                style: .success,
+                title: "This is a toast message",
+                edge: .top,
+                duration: .custom(interval: dissapearAfterTime),
+                isPresented: Binding<Bool>(
+                    get: { isPresented },
+                    set: { isPresented = $0 }
+                )
+            )
+        let window = viewShouldAppearOnScreen(toast)
+        defer {
+            window.windowScene = nil // clean up the window
+        }
+
+        #expect(isPresented == true, "Toast should be presented initially")
+        try await Task.sleep(timeInterval: waitingTime)
+        #expect(isPresented == false, "Toast should disappear after \(dissapearAfterTime) seconds")
+    }
+
+    private func viewShouldAppearOnScreen(_ view: some View) -> UIWindow {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let hostingVC = UIHostingController(rootView: view)
+        window.rootViewController = hostingVC
+        window.makeKeyAndVisible()
+        return window
+    }
+}
+
+extension Task where Success == Never, Failure == Never {
+    
+    static func sleep(timeInterval: TimeInterval) async throws {
+        let nanoseconds = UInt64(timeInterval * 1_000_000_000)
+        try await Task.sleep(nanoseconds: nanoseconds)
+    }
+}


### PR DESCRIPTION
Setup `Toast.Duration` enum with predefined time cases (+ custom interval), add logic which automatically dismiss toast after that. Additionally add `maxWidth` constraint to toast view (as defined in doc)