### PR TITLE
Update components to SwiftUI `@Environment` theme injection

### DIFF
--- a/ENVIRONMENT_MIGRATION.md
+++ b/ENVIRONMENT_MIGRATION.md
@@ -1,0 +1,355 @@
+# Migration Guide: Global Theme → Environment-Based Injection
+
+This guide explains how to migrate from the global `Warp.Theme` variable to the new `@Environment`-based theme injection system.
+
+## Why Migrate?
+
+The old global approach has several problems:
+
+1. **Not Swift 6 concurrency-safe**: Global mutable state violates strict concurrency rules
+2. **Hard to test**: Can't test different themes in parallel
+3. **Unexpected side effects**: Changing `Warp.Theme` affects all views globally
+4. **Preview pollution**: Preview modifiers mutate global state
+5. **Poor encapsulation**: Views implicitly depend on global state
+
+The new system uses SwiftUI's `@Environment` for proper dependency injection.
+
+## Migration Steps
+
+### 1. Update App Entry Point
+
+**Before:**
+```swift
+@main
+struct MyApp: App {
+    init() {
+        Warp.Theme = .finn  // ❌ Global mutation
+    }
+    
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+```
+
+**After:**
+```swift
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .warpTheme(.finn)  // ✅ Environment injection
+        }
+    }
+}
+```
+
+### 2. Update View Code
+
+**Before:**
+```swift
+struct MyView: View {
+    var body: some View {
+        Text("Hello")
+            .foregroundColor(Warp.Color.textPrimary)  // ❌ Uses global Warp.Theme
+    }
+}
+```
+
+**After:**
+```swift
+struct MyView: View {
+    @Environment(\.warpTheme) private var theme
+    
+    var body: some View {
+        Text("Hello")
+            .foregroundColor(ColorProvider(theme: theme).textPrimary)  // ✅ Explicit theme
+    }
+}
+```
+
+### 3. Update Previews
+
+**Before:**
+```swift
+#Preview {
+    Warp.Theme = .tori  // ❌ Mutates global state
+    return MyView()
+}
+```
+
+**After (iOS 18+):**
+```swift
+#Preview(traits: .themeTori) {  // ✅ Environment injection
+    MyView()
+}
+```
+
+**After (iOS 17 and earlier):**
+```swift
+#Preview {
+    MyView()
+        .warpTheme(.tori)  // ✅ Environment injection
+}
+```
+
+### 4. Update Font Registration
+
+**Before:**
+```swift
+Warp.Theme = .finn
+try? Warp.Typography.registerFonts()  // ❌ Uses global theme
+```
+
+**After:**
+```swift
+let theme = Warp.Brand.finn
+try? Warp.Typography.registerFonts(for: theme)  // ✅ Explicit theme
+```
+
+### 5. Update Tests
+
+**Before:**
+```swift
+func testMyView() {
+    Warp.Theme = .dba  // ❌ Pollutes test isolation
+    let view = MyView()
+    // ...
+}
+```
+
+**After:**
+```swift
+func testMyView() {
+    let view = MyView()
+        .warpTheme(.dba)  // ✅ Test-scoped theme
+    // ...
+}
+```
+
+## API Reference
+
+### New APIs
+
+#### Environment Key
+```swift
+@Environment(\.warpTheme) private var theme: Warp.Brand
+```
+
+#### View Modifier
+```swift
+.warpTheme(_ theme: Warp.Brand) -> some View
+```
+
+#### ColorProvider
+```swift
+ColorProvider(theme: Warp.Brand)  // ✅ New primary initializer
+ColorProvider(token: TokenProvider)  // ⚠️ Deprecated, still uses global theme
+```
+
+#### UIColorProvider
+```swift
+UIColorProvider(theme: Warp.Brand)  // ✅ New primary initializer
+UIColorProvider(token: UITokenProvider)  // ⚠️ Deprecated, still uses global theme
+```
+
+#### Typography
+```swift
+Warp.Typography.registerFonts(for: Warp.Brand)  // ✅ New
+Warp.Typography.registerFonts()  // ⚠️ Deprecated, uses global theme
+```
+
+#### Font
+```swift
+Warp.Font.fonts(for: Warp.Brand)  // ✅ New
+Warp.Font.fontForTheme  // ⚠️ Deprecated, uses global theme
+```
+
+### Deprecated APIs
+
+These still work but show warnings:
+
+- `Warp.Color` → Use `ColorProvider(theme:)` with `@Environment(\.warpTheme)`
+- `Warp.UIColor` → Use `UIColorProvider(theme:)` with `@Environment(\.warpTheme)`
+- `ColorProvider(token:)` → Use `ColorProvider(theme:)`
+- `UIColorProvider(token:)` → Use `UIColorProvider(theme:)`
+- `Warp.Typography.registerFonts()` → Use `registerFonts(for:)`
+- `Warp.Font.fontForTheme` → Use `fonts(for:)`
+
+## Advanced Patterns
+
+### Theme Switching at Runtime
+
+**Before:**
+```swift
+Button("Switch Theme") {
+    Warp.Theme = .tori  // ❌ Global mutation
+}
+```
+
+**After:**
+```swift
+@State private var currentTheme: Warp.Brand = .finn
+
+var body: some View {
+    VStack {
+        MyContent()
+        
+        Button("Switch Theme") {
+            currentTheme = .tori  // ✅ Local state
+        }
+    }
+    .warpTheme(currentTheme)
+}
+```
+
+### Passing Theme to Child Views
+
+The environment automatically propagates:
+
+```swift
+struct ParentView: View {
+    var body: some View {
+        VStack {
+            ChildView()  // Automatically inherits theme
+        }
+        .warpTheme(.finn)
+    }
+}
+
+struct ChildView: View {
+    @Environment(\.warpTheme) private var theme  // ✅ Gets .finn
+    
+    var body: some View {
+        Text("Themed text")
+            .foregroundColor(ColorProvider(theme: theme).textPrimary)
+    }
+}
+```
+
+### Testing Different Themes in Parallel
+
+Now possible with environment isolation:
+
+```swift
+func testAllThemes() async {
+    await withTaskGroup(of: Void.self) { group in
+        for theme in Warp.Brand.allCases {
+            group.addTask {
+                let view = MyView().warpTheme(theme)
+                // Test view with this theme
+            }
+        }
+    }
+}
+```
+
+## Common Pitfalls
+
+### ❌ Forgetting to inject theme
+```swift
+struct MyView: View {
+    @Environment(\.warpTheme) private var theme
+    var body: some View {
+        // Using Warp.Color instead of ColorProvider(theme: theme)
+        Text("Hello").foregroundColor(Warp.Color.textPrimary)  // ❌ Still uses global
+    }
+}
+```
+
+**Fix:** Use the environment value:
+```swift
+Text("Hello").foregroundColor(ColorProvider(theme: theme).textPrimary)  // ✅
+```
+
+### ❌ Setting theme too late in view hierarchy
+```swift
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            FirstTab().warpTheme(.finn)   // ❌ Different themes per tab?
+            SecondTab().warpTheme(.tori)  // ❌ Probably not what you want
+        }
+    }
+}
+```
+
+**Fix:** Set theme at the root:
+```swift
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            FirstTab()
+            SecondTab()
+        }
+        .warpTheme(.finn)  // ✅ Consistent theme for whole app
+    }
+}
+```
+
+## Backwards Compatibility
+
+The global `Warp.Theme` still works for backwards compatibility, but shows deprecation warnings. You can migrate incrementally:
+
+1. **Phase 1**: Add `.warpTheme()` at app root
+2. **Phase 2**: Update views one by one to use `@Environment(\.warpTheme)`
+3. **Phase 3**: Remove all `Warp.Theme` assignments
+4. **Phase 4**: Update generators to emit theme-parameter code
+
+The deprecated APIs will continue to work until a future major version.
+
+## Generator Updates
+
+If you're using the token generator from https://github.com/warp-ds/tokens:
+
+### ColorProvider Generator
+
+Update to emit:
+```swift
+public struct ColorProvider {
+    public let theme: Warp.Brand
+    public let token: TokenProvider
+    
+    public init(theme: Warp.Brand) {
+        self.theme = theme
+        self.token = Self.tokenProvider(for: theme)
+    }
+    
+    public var badgeNeutralBackground: Color {
+        switch theme {  // Use parameter, not Warp.Theme
+            // ...
+        }
+    }
+}
+```
+
+## Swift 6 Concurrency Benefits
+
+The new system is fully Swift 6 strict concurrency compliant:
+
+```swift
+// ✅ Sendable-safe
+struct ColorProvider: Sendable {
+    public let theme: Warp.Brand  // Sendable enum
+    public let token: TokenProvider  // Sendable struct
+    // ...
+}
+
+// ✅ No data races
+@MainActor
+struct MyView: View {
+    @Environment(\.warpTheme) private var theme  // Isolated to MainActor
+    // ...
+}
+```
+
+## Questions?
+
+See the Swift 6 concurrency audit report for related concurrency issues:
+- Missing `@MainActor` on UIViewControllers
+- Legacy `DispatchQueue` patterns to modernize
+
+For issues or feedback, file an issue at: [your repo URL]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "warp-ios",
     platforms: [
-        .iOS(.v15)
+        .iOS(.v17)
     ],
     products: [
         .library(

--- a/SampleApp/Blocket/Warp_iosBlocket.swift
+++ b/SampleApp/Blocket/Warp_iosBlocket.swift
@@ -6,13 +6,15 @@ import FirebaseCore
 struct Wrap_iosBlocket: App {
 
     init() {
-        Warp.Theme = .blocket
+        // Register fonts for the Blocket theme
+        try? Warp.Typography.registerFonts(for: .blocket)
         FirebaseApp.configure()
     }
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .warpTheme(.blocket)
         }
     }
 }

--- a/SampleApp/Blocket/Warp_iosBlocket.swift
+++ b/SampleApp/Blocket/Warp_iosBlocket.swift
@@ -7,7 +7,7 @@ struct Wrap_iosBlocket: App {
 
     init() {
         // Register fonts for the Blocket theme
-        try? Warp.Typography.registerFonts(for: .blocket)
+        try! Warp.Typography.registerFonts(for: .blocket)
         FirebaseApp.configure()
     }
 

--- a/SampleApp/BrandItems/TypographyUIView.swift
+++ b/SampleApp/BrandItems/TypographyUIView.swift
@@ -2,6 +2,7 @@ import UIKit
 import SwiftUI
 import Warp
 
+@MainActor
 class UITypographyViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,6 +43,7 @@ class UITypographyViewController: UIViewController {
     }
 }
 
+@MainActor
 struct TypographyUIView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
         return UITypographyViewController()

--- a/SampleApp/Components/ShadowUIView.swift
+++ b/SampleApp/Components/ShadowUIView.swift
@@ -2,6 +2,7 @@ import UIKit
 import SwiftUI
 import Warp
 
+@MainActor
 class UIShadowViewController: UIViewController {
     private let segmentedControl: UISegmentedControl = {
         let items = Warp.Shadow.allCases.map { $0.name }
@@ -82,6 +83,7 @@ class UIShadowViewController: UIViewController {
     }
 }
 
+@MainActor
 struct ShadowUIView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
         return UIShadowViewController()

--- a/SampleApp/ContentView.swift
+++ b/SampleApp/ContentView.swift
@@ -16,9 +16,6 @@ struct ContentView: View {
                 }
                 .pickerStyle(.segmented)
                 .padding(.horizontal)
-                .onChange(of: selectedTheme) { newValue in
-                    Warp.Theme = selectedTheme
-                }
                 #endif
                 LazyVStack (alignment: .leading) {
                     Warp.Text("Brand Specific Items", style: .title3)
@@ -83,13 +80,25 @@ struct ContentView: View {
             }
             .navigationTitle(Bundle.main.applicationName)
         }
+        .warpTheme(selectedTheme)
     }
     
     private func row(_ title: String, destination: some View) -> some View {
+        RowView(title: title, destination: destination)
+    }
+}
+
+/// Individual row view for navigation links with theme-aware styling
+private struct RowView<Destination: View>: View {
+    let title: String
+    let destination: Destination
+    @Environment(\.warpTheme) private var theme
+
+    var body: some View {
         NavigationLink(destination: destination) {
             VStack(alignment: .leading) {
                 Warp.Text(title, style: .title4)
-                    .foregroundColor(Warp.Token.textLink)
+                    .foregroundColor(ColorProvider(theme: theme).token.textLink)
                     .padding()
                 Divider()
             }

--- a/SampleApp/DBA/Warp_iosDBA.swift
+++ b/SampleApp/DBA/Warp_iosDBA.swift
@@ -6,13 +6,15 @@ import FirebaseCore
 struct Wrap_iosDBA: App {
 
     init() {
-        Warp.Theme = .dba
+        // Register fonts for the DBA theme
+        try? Warp.Typography.registerFonts(for: .dba)
         FirebaseApp.configure()
     }
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .warpTheme(.dba)
         }
     }
 }

--- a/SampleApp/DBA/Warp_iosDBA.swift
+++ b/SampleApp/DBA/Warp_iosDBA.swift
@@ -7,7 +7,7 @@ struct Wrap_iosDBA: App {
 
     init() {
         // Register fonts for the DBA theme
-        try? Warp.Typography.registerFonts(for: .dba)
+        try! Warp.Typography.registerFonts(for: .dba)
         FirebaseApp.configure()
     }
 

--- a/SampleApp/Finn/Warp_iosFinn.swift
+++ b/SampleApp/Finn/Warp_iosFinn.swift
@@ -4,15 +4,17 @@ import FirebaseCore
 
 @main
 struct Wrap_iosFinn: App {
-    
+
     init() {
-        Warp.Theme = .finn
+        // Register fonts for the Finn theme
+        try? Warp.Typography.registerFonts(for: .finn)
         FirebaseApp.configure()
     }
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .warpTheme(.finn)
         }
     }
 }

--- a/SampleApp/Finn/Warp_iosFinn.swift
+++ b/SampleApp/Finn/Warp_iosFinn.swift
@@ -7,7 +7,7 @@ struct Wrap_iosFinn: App {
 
     init() {
         // Register fonts for the Finn theme
-        try? Warp.Typography.registerFonts(for: .finn)
+        try! Warp.Typography.registerFonts(for: .finn)
         FirebaseApp.configure()
     }
 

--- a/SampleApp/Tori/Warp_iosTori.swift
+++ b/SampleApp/Tori/Warp_iosTori.swift
@@ -7,7 +7,7 @@ struct Wrap_iosTori: App {
 
     init() {
         // Register fonts for the Tori theme
-        try? Warp.Typography.registerFonts(for: .tori)
+        try! Warp.Typography.registerFonts(for: .tori)
         FirebaseApp.configure()
     }
 

--- a/SampleApp/Tori/Warp_iosTori.swift
+++ b/SampleApp/Tori/Warp_iosTori.swift
@@ -4,15 +4,17 @@ import FirebaseCore
 
 @main
 struct Wrap_iosTori: App {
-    
+
     init() {
-        Warp.Theme = .tori
+        // Register fonts for the Tori theme
+        try? Warp.Typography.registerFonts(for: .tori)
         FirebaseApp.configure()
     }
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .warpTheme(.tori)
         }
     }
 }

--- a/SampleApp/Vend/Warp_iosVend.swift
+++ b/SampleApp/Vend/Warp_iosVend.swift
@@ -6,13 +6,15 @@ import FirebaseCore
 struct Wrap_iosVend: App {
 
     init() {
-        Warp.Theme = .vend
+        // Register fonts for the Vend theme
+        try? Warp.Typography.registerFonts(for: .vend)
         FirebaseApp.configure()
     }
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .warpTheme(.vend)
         }
     }
 }

--- a/SampleApp/Vend/Warp_iosVend.swift
+++ b/SampleApp/Vend/Warp_iosVend.swift
@@ -7,7 +7,7 @@ struct Wrap_iosVend: App {
 
     init() {
         // Register fonts for the Vend theme
-        try? Warp.Typography.registerFonts(for: .vend)
+        try! Warp.Typography.registerFonts(for: .vend)
         FirebaseApp.configure()
     }
 

--- a/SampleApp/Warp-iosSampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/Warp-iosSampleApp.xcodeproj/project.pbxproj
@@ -1243,7 +1243,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1280,7 +1280,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1317,7 +1317,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1354,7 +1354,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1391,7 +1391,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1428,7 +1428,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1579,7 +1579,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1616,7 +1616,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1653,7 +1653,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1690,7 +1690,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1727,7 +1727,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1765,7 +1765,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/SampleApp/WarpDemo/Warp_iosDemo.swift
+++ b/SampleApp/WarpDemo/Warp_iosDemo.swift
@@ -4,15 +4,17 @@ import FirebaseCore
 
 @main
 struct Wrap_iosDemo: App {
-    
+
     init() {
-        Warp.Theme = .finn
+        // Register fonts for the demo theme (using Finn by default)
+        try? Warp.Typography.registerFonts(for: .finn)
         FirebaseApp.configure()
     }
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .warpTheme(.finn)
         }
     }
 }

--- a/SampleApp/WarpDemo/Warp_iosDemo.swift
+++ b/SampleApp/WarpDemo/Warp_iosDemo.swift
@@ -7,7 +7,7 @@ struct Wrap_iosDemo: App {
 
     init() {
         // Register all brand fonts for dynamic theme switching
-        for theme in Warp.Theme.allCases {
+        for theme in Warp.Brand.allCases {
             try! Warp.Typography.registerFonts(for: theme)
         }
         FirebaseApp.configure()

--- a/SampleApp/WarpDemo/Warp_iosDemo.swift
+++ b/SampleApp/WarpDemo/Warp_iosDemo.swift
@@ -6,15 +6,17 @@ import FirebaseCore
 struct Wrap_iosDemo: App {
 
     init() {
-        // Register fonts for the demo theme (using Finn by default)
-        try? Warp.Typography.registerFonts(for: .finn)
+        // Register all brand fonts for dynamic theme switching
+        for theme in Warp.Theme.allCases {
+            try! Warp.Typography.registerFonts(for: theme)
+        }
         FirebaseApp.configure()
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .warpTheme(.finn)
+                .warpTheme(.finn) // Set default theme to Finn, but can be switched dynamically in the app
         }
     }
 }

--- a/Sources/Border/Border.swift
+++ b/Sources/Border/Border.swift
@@ -8,7 +8,8 @@ extension Warp {
         /// Border radius of 2 points. Typically used for very small rounded corners.
         public static let borderRadius25: CGFloat = 2
         /// Border radius of 4 points. A slightly larger rounded corner for small elements.
-        public static let borderRadius50: CGFloat = 4
+        public static let
+            borderRadius50: CGFloat = 4
         /// Border radius of 8 points. Suitable for medium-sized elements with rounded corners.
         public static let borderRadius100: CGFloat = 8
         /// Border radius of 16 points. Ideal for larger elements or prominent rounded corners.

--- a/Sources/Border/Border.swift
+++ b/Sources/Border/Border.swift
@@ -8,8 +8,7 @@ extension Warp {
         /// Border radius of 2 points. Typically used for very small rounded corners.
         public static let borderRadius25: CGFloat = 2
         /// Border radius of 4 points. A slightly larger rounded corner for small elements.
-        public static let
-            borderRadius50: CGFloat = 4
+        public static let borderRadius50: CGFloat = 4
         /// Border radius of 8 points. Suitable for medium-sized elements with rounded corners.
         public static let borderRadius100: CGFloat = 8
         /// Border radius of 16 points. Ideal for larger elements or prominent rounded corners.

--- a/Sources/Colors/ColorProvider.swift
+++ b/Sources/Colors/ColorProvider.swift
@@ -1,11 +1,39 @@
 import SwiftUI
 
 // Generated on Wed, 04 Mar 2026 08:12:23 GMT by https://github.com/warp-ds/tokens
+// NOTE: Generator should be updated to accept theme parameter instead of using Warp.Theme global
 public struct ColorProvider {
     public let token: TokenProvider
+    public let theme: Warp.Brand
+
+    /// Initialize ColorProvider with a specific theme
+    /// - Parameter theme: The brand theme to use
+    public init(theme: Warp.Brand) {
+        self.theme = theme
+        self.token = Self.tokenProvider(for: theme)
+    }
+
+    /// Backwards compatibility initializer using token
+    /// - Parameter token: The token provider (theme will be inferred from Warp.Theme global)
+    @available(*, deprecated, message: "Use init(theme:) instead to avoid global state")
+    public init(token: TokenProvider) {
+        self.token = token
+        self.theme = Warp.Theme
+    }
+
+    private static func tokenProvider(for theme: Warp.Brand) -> TokenProvider {
+        switch theme {
+        case .finn: return FinnTokenProvider()
+        case .tori: return ToriTokenProvider()
+        case .dba: return DbaTokenProvider()
+        case .blocket: return BlocketTokenProvider()
+        case .vend: return VendTokenProvider()
+        case .neutral: return NeutralTokenProvider()
+        }
+    }
     
     public var badgeNeutralBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.gray100, darkModeColor: BlocketColors.gray600)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.gray100, darkModeColor: DbaColors.gray600)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.gray100, darkModeColor: FinnColors.gray600)
@@ -16,7 +44,7 @@ public struct ColorProvider {
     }
     
     public var badgePositiveBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.green100, darkModeColor: BlocketColors.green700)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.green100, darkModeColor: DbaColors.green700)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.green100, darkModeColor: FinnColors.green700)
@@ -27,7 +55,7 @@ public struct ColorProvider {
     }
     
     public var badgeInfoBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.blue100, darkModeColor: BlocketColors.blue700)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.jeanblue100, darkModeColor: DbaColors.jeanblue700)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.aqua100, darkModeColor: FinnColors.aqua700)
@@ -38,7 +66,7 @@ public struct ColorProvider {
     }
     
     public var badgeWarningBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.yellow100, darkModeColor: BlocketColors.yellow700)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.yellow100, darkModeColor: DbaColors.yellow700)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.yellow100, darkModeColor: FinnColors.yellow700)
@@ -49,7 +77,7 @@ public struct ColorProvider {
     }
     
     public var badgeNegativeBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.coral100, darkModeColor: BlocketColors.coral700)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.red100, darkModeColor: DbaColors.red700)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.red100, darkModeColor: FinnColors.red700)
@@ -60,7 +88,7 @@ public struct ColorProvider {
     }
     
     public var badgeSponsoredBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.blue200, darkModeColor: BlocketColors.blue600)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.jeanblue200, darkModeColor: DbaColors.jeanblue600)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.aqua200, darkModeColor: FinnColors.aqua600)
@@ -71,7 +99,7 @@ public struct ColorProvider {
     }
     
     public var badgePriceBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketColors.black
         case .dba: return DbaColors.black
         case .finn: return FinnColors.black
@@ -82,7 +110,7 @@ public struct ColorProvider {
     }
     
     public var buttonPrimaryBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return token.backgroundPrimary
         case .dba: return token.backgroundPrimary
         case .finn: return token.backgroundPrimary
@@ -93,7 +121,7 @@ public struct ColorProvider {
     }
     
     public var buttonPrimaryBackgroundHover: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return token.backgroundPrimaryHover
         case .dba: return token.backgroundPrimaryHover
         case .finn: return token.backgroundPrimaryHover
@@ -104,7 +132,7 @@ public struct ColorProvider {
     }
     
     public var buttonPrimaryBackgroundActive: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return token.backgroundPrimaryActive
         case .dba: return token.backgroundPrimaryActive
         case .finn: return token.backgroundPrimaryActive
@@ -115,7 +143,7 @@ public struct ColorProvider {
     }
     
     public var buttonPillBackgroundHover: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketColors.blue300
         case .dba: return DbaColors.jeanblue300
         case .finn: return FinnColors.blue300
@@ -126,7 +154,7 @@ public struct ColorProvider {
     }
     
     public var buttonPillBackgroundActive: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketColors.blue400
         case .dba: return DbaColors.jeanblue400
         case .finn: return FinnColors.blue400
@@ -137,7 +165,7 @@ public struct ColorProvider {
     }
     
     public var calloutBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.green100, darkModeColor: BlocketColors.green800)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.green100, darkModeColor: DbaColors.green800)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.green100, darkModeColor: FinnColors.green800)
@@ -148,7 +176,7 @@ public struct ColorProvider {
     }
     
     public var calloutBorder: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.green400, darkModeColor: BlocketColors.green600)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.green400, darkModeColor: DbaColors.green600)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.green400, darkModeColor: FinnColors.green600)
@@ -159,7 +187,7 @@ public struct ColorProvider {
     }
     
     public var cardBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return token.background
         case .dba: return token.background
         case .finn: return token.background
@@ -170,7 +198,7 @@ public struct ColorProvider {
     }
     
     public var navbarIconSelected: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return token.iconSecondary
         case .dba: return token.iconSecondary
         case .finn: return token.iconSelected
@@ -181,7 +209,7 @@ public struct ColorProvider {
     }
     
     public var navbarBorderSelected: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return token.borderSecondary
         case .dba: return token.borderSecondary
         case .finn: return token.borderSelected
@@ -192,7 +220,7 @@ public struct ColorProvider {
     }
     
     public var pageIndicatorBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketColors.gray300
         case .dba: return DbaColors.gray300
         case .finn: return FinnColors.gray300
@@ -203,7 +231,7 @@ public struct ColorProvider {
     }
     
     public var pageIndicatorBackgroundHover: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.gray400, darkModeColor: BlocketColors.gray200)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.gray400, darkModeColor: DbaColors.gray200)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.gray400, darkModeColor: FinnColors.gray200)
@@ -214,7 +242,7 @@ public struct ColorProvider {
     }
     
     public var pillSuggestionBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.gray200, darkModeColor: BlocketColors.gray600)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.gray200, darkModeColor: DbaColors.gray600)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.gray200, darkModeColor: FinnColors.gray600)
@@ -225,7 +253,7 @@ public struct ColorProvider {
     }
     
     public var pillSuggestionBackgroundHover: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.gray300, darkModeColor: BlocketColors.gray500)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.gray300, darkModeColor: DbaColors.gray500)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.gray300, darkModeColor: FinnColors.gray500)
@@ -236,7 +264,7 @@ public struct ColorProvider {
     }
     
     public var pillSuggestionBackgroundActive: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketColors.gray400
         case .dba: return DbaColors.gray400
         case .finn: return FinnColors.gray400
@@ -247,7 +275,7 @@ public struct ColorProvider {
     }
     
     public var tooltipBackgroundStatic: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: token.backgroundInverted, darkModeColor: token.surfaceElevated300)
         case .dba: return Color.dynamicColor(defaultColor: token.backgroundInverted, darkModeColor: token.surfaceElevated300)
         case .finn: return Color.dynamicColor(defaultColor: token.backgroundInverted, darkModeColor: token.surfaceElevated300)
@@ -258,7 +286,7 @@ public struct ColorProvider {
     }
     
     public var switchHandleBackground: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketColors.gray500
         case .dba: return DbaColors.gray500
         case .finn: return FinnColors.gray500
@@ -269,7 +297,7 @@ public struct ColorProvider {
     }
     
     public var switchHandleBackgroundHover: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.gray600, darkModeColor: BlocketColors.gray400)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.gray600, darkModeColor: DbaColors.gray400)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.gray600, darkModeColor: FinnColors.gray400)
@@ -280,7 +308,7 @@ public struct ColorProvider {
     }
     
     public var switchTrackBorder: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketColors.gray500
         case .dba: return DbaColors.gray500
         case .finn: return FinnColors.gray500
@@ -291,7 +319,7 @@ public struct ColorProvider {
     }
     
     public var switchTrackBorderHover: Color {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return Color.dynamicColor(defaultColor: BlocketColors.gray600, darkModeColor: BlocketColors.gray400)
         case .dba: return Color.dynamicColor(defaultColor: DbaColors.gray600, darkModeColor: DbaColors.gray400)
         case .finn: return Color.dynamicColor(defaultColor: FinnColors.gray600, darkModeColor: FinnColors.gray400)
@@ -304,9 +332,36 @@ public struct ColorProvider {
 
 public struct UIColorProvider {
     public let token: UITokenProvider
+    public let theme: Warp.Brand
+
+    /// Initialize UIColorProvider with a specific theme
+    /// - Parameter theme: The brand theme to use
+    public init(theme: Warp.Brand) {
+        self.theme = theme
+        self.token = Self.tokenProvider(for: theme)
+    }
+
+    /// Backwards compatibility initializer using token
+    /// - Parameter token: The token provider (theme will be inferred from Warp.Theme global)
+    @available(*, deprecated, message: "Use init(theme:) instead to avoid global state")
+    public init(token: UITokenProvider) {
+        self.token = token
+        self.theme = Warp.Theme
+    }
+
+    private static func tokenProvider(for theme: Warp.Brand) -> UITokenProvider {
+        switch theme {
+        case .finn: return FinnUITokenProvider()
+        case .tori: return ToriUITokenProvider()
+        case .dba: return DbaUITokenProvider()
+        case .blocket: return BlocketUITokenProvider()
+        case .vend: return VendUITokenProvider()
+        case .neutral: return NeutralUITokenProvider()
+        }
+    }
     
     public var badgeNeutralBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.gray100, darkModeColor: BlocketUIColors.gray600)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.gray100, darkModeColor: DbaUIColors.gray600)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.gray100, darkModeColor: FinnUIColors.gray600)
@@ -317,7 +372,7 @@ public struct UIColorProvider {
     }
     
     public var badgePositiveBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.green100, darkModeColor: BlocketUIColors.green700)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.green100, darkModeColor: DbaUIColors.green700)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.green100, darkModeColor: FinnUIColors.green700)
@@ -328,7 +383,7 @@ public struct UIColorProvider {
     }
     
     public var badgeInfoBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.blue100, darkModeColor: BlocketUIColors.blue700)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.jeanblue100, darkModeColor: DbaUIColors.jeanblue700)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.aqua100, darkModeColor: FinnUIColors.aqua700)
@@ -339,7 +394,7 @@ public struct UIColorProvider {
     }
     
     public var badgeWarningBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.yellow100, darkModeColor: BlocketUIColors.yellow700)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.yellow100, darkModeColor: DbaUIColors.yellow700)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.yellow100, darkModeColor: FinnUIColors.yellow700)
@@ -350,7 +405,7 @@ public struct UIColorProvider {
     }
     
     public var badgeNegativeBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.coral100, darkModeColor: BlocketUIColors.coral700)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.red100, darkModeColor: DbaUIColors.red700)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.red100, darkModeColor: FinnUIColors.red700)
@@ -361,7 +416,7 @@ public struct UIColorProvider {
     }
     
     public var badgeSponsoredBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.blue200, darkModeColor: BlocketUIColors.blue600)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.jeanblue200, darkModeColor: DbaUIColors.jeanblue600)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.aqua200, darkModeColor: FinnUIColors.aqua600)
@@ -372,7 +427,7 @@ public struct UIColorProvider {
     }
     
     public var badgePriceBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketUIColors.black
         case .dba: return DbaUIColors.black
         case .finn: return FinnUIColors.black
@@ -383,7 +438,7 @@ public struct UIColorProvider {
     }
     
     public var buttonPrimaryBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return token.backgroundPrimary
         case .dba: return token.backgroundPrimary
         case .finn: return token.backgroundPrimary
@@ -394,7 +449,7 @@ public struct UIColorProvider {
     }
     
     public var buttonPrimaryBackgroundHover: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return token.backgroundPrimaryHover
         case .dba: return token.backgroundPrimaryHover
         case .finn: return token.backgroundPrimaryHover
@@ -405,7 +460,7 @@ public struct UIColorProvider {
     }
     
     public var buttonPrimaryBackgroundActive: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return token.backgroundPrimaryActive
         case .dba: return token.backgroundPrimaryActive
         case .finn: return token.backgroundPrimaryActive
@@ -416,7 +471,7 @@ public struct UIColorProvider {
     }
     
     public var buttonPillBackgroundHover: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketUIColors.blue300
         case .dba: return DbaUIColors.jeanblue300
         case .finn: return FinnUIColors.blue300
@@ -427,7 +482,7 @@ public struct UIColorProvider {
     }
     
     public var buttonPillBackgroundActive: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketUIColors.blue400
         case .dba: return DbaUIColors.jeanblue400
         case .finn: return FinnUIColors.blue400
@@ -438,7 +493,7 @@ public struct UIColorProvider {
     }
     
     public var calloutBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.green100, darkModeColor: BlocketUIColors.green800)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.green100, darkModeColor: DbaUIColors.green800)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.green100, darkModeColor: FinnUIColors.green800)
@@ -449,7 +504,7 @@ public struct UIColorProvider {
     }
     
     public var calloutBorder: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.green400, darkModeColor: BlocketUIColors.green600)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.green400, darkModeColor: DbaUIColors.green600)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.green400, darkModeColor: FinnUIColors.green600)
@@ -460,7 +515,7 @@ public struct UIColorProvider {
     }
     
     public var cardBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return token.background
         case .dba: return token.background
         case .finn: return token.background
@@ -471,7 +526,7 @@ public struct UIColorProvider {
     }
     
     public var navbarIconSelected: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return token.iconSecondary
         case .dba: return token.iconSecondary
         case .finn: return token.iconSelected
@@ -482,7 +537,7 @@ public struct UIColorProvider {
     }
     
     public var navbarBorderSelected: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return token.borderSecondary
         case .dba: return token.borderSecondary
         case .finn: return token.borderSelected
@@ -493,7 +548,7 @@ public struct UIColorProvider {
     }
     
     public var pageIndicatorBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketUIColors.gray300
         case .dba: return DbaUIColors.gray300
         case .finn: return FinnUIColors.gray300
@@ -504,7 +559,7 @@ public struct UIColorProvider {
     }
     
     public var pageIndicatorBackgroundHover: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.gray400, darkModeColor: BlocketUIColors.gray200)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.gray400, darkModeColor: DbaUIColors.gray200)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.gray400, darkModeColor: FinnUIColors.gray200)
@@ -515,7 +570,7 @@ public struct UIColorProvider {
     }
     
     public var pillSuggestionBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.gray200, darkModeColor: BlocketUIColors.gray600)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.gray200, darkModeColor: DbaUIColors.gray600)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.gray200, darkModeColor: FinnUIColors.gray600)
@@ -526,7 +581,7 @@ public struct UIColorProvider {
     }
     
     public var pillSuggestionBackgroundHover: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.gray300, darkModeColor: BlocketUIColors.gray500)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.gray300, darkModeColor: DbaUIColors.gray500)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.gray300, darkModeColor: FinnUIColors.gray500)
@@ -537,7 +592,7 @@ public struct UIColorProvider {
     }
     
     public var pillSuggestionBackgroundActive: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketUIColors.gray400
         case .dba: return DbaUIColors.gray400
         case .finn: return FinnUIColors.gray400
@@ -548,7 +603,7 @@ public struct UIColorProvider {
     }
     
     public var tooltipBackgroundStatic: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: token.backgroundInverted, darkModeColor: token.surfaceElevated300)
         case .dba: return UIColor.dynamicColor(defaultColor: token.backgroundInverted, darkModeColor: token.surfaceElevated300)
         case .finn: return UIColor.dynamicColor(defaultColor: token.backgroundInverted, darkModeColor: token.surfaceElevated300)
@@ -559,7 +614,7 @@ public struct UIColorProvider {
     }
     
     public var switchHandleBackground: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketUIColors.gray500
         case .dba: return DbaUIColors.gray500
         case .finn: return FinnUIColors.gray500
@@ -570,7 +625,7 @@ public struct UIColorProvider {
     }
     
     public var switchHandleBackgroundHover: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.gray600, darkModeColor: BlocketUIColors.gray400)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.gray600, darkModeColor: DbaUIColors.gray400)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.gray600, darkModeColor: FinnUIColors.gray400)
@@ -581,7 +636,7 @@ public struct UIColorProvider {
     }
     
     public var switchTrackBorder: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return BlocketUIColors.gray500
         case .dba: return DbaUIColors.gray500
         case .finn: return FinnUIColors.gray500
@@ -592,7 +647,7 @@ public struct UIColorProvider {
     }
     
     public var switchTrackBorderHover: UIColor {
-        switch Warp.Theme {
+        switch theme {
         case .blocket: return UIColor.dynamicColor(defaultColor: BlocketUIColors.gray600, darkModeColor: BlocketUIColors.gray400)
         case .dba: return UIColor.dynamicColor(defaultColor: DbaUIColors.gray600, darkModeColor: DbaUIColors.gray400)
         case .finn: return UIColor.dynamicColor(defaultColor: FinnUIColors.gray600, darkModeColor: FinnUIColors.gray400)

--- a/Sources/Components/Alert/Alert.swift
+++ b/Sources/Components/Alert/Alert.swift
@@ -32,9 +32,14 @@ extension Warp {
         /// A tuple that provides a title and action for creating a secondary button below the link.
         /// Passing `nil` will skip adding the secondary button.
         private let secondaryButtonProvider: ButtonConstructor?
-        
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object responsible for providing colors across different environments and variants.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         /// Hashing implementation for the `Alert` structure, ensuring proper usage in collections.
         public func hash(into hasher: inout Hasher) {
@@ -194,7 +199,7 @@ extension Warp {
                                 style: .body,
                                 color: colorProvider.token.textLink
                             )
-                            .modifier(UnderlinedLinkModifier(colorProvider: colorProvider))
+                            .modifier(UnderlinedLinkModifier())
                             Spacer()
                         }
                     }
@@ -208,8 +213,7 @@ extension Warp {
         private var buttonsView: some View {
             ButtonsView(
                 primaryButtonProvider: primaryButtonProvider,
-                secondaryButtonProvider: secondaryButtonProvider,
-                colorProvider: colorProvider
+                secondaryButtonProvider: secondaryButtonProvider
             )
         }
     }
@@ -219,9 +223,7 @@ private struct ButtonsView: View, Hashable {
     let primaryButtonProvider: Warp.Alert.ButtonConstructor?
     
     let secondaryButtonProvider: Warp.Alert.ButtonConstructor?
-    
-    let colorProvider: ColorProvider
-    
+        
     static func == (lhs: ButtonsView, rhs: ButtonsView) -> Bool {
         let primaryComparison: Bool
         
@@ -270,8 +272,7 @@ private struct ButtonsView: View, Hashable {
     
     init?(
         primaryButtonProvider: Warp.Alert.ButtonConstructor?,
-        secondaryButtonProvider: Warp.Alert.ButtonConstructor?,
-        colorProvider: ColorProvider
+        secondaryButtonProvider: Warp.Alert.ButtonConstructor?
     ) {
         if primaryButtonProvider == nil, secondaryButtonProvider == nil {
             return nil
@@ -279,7 +280,6 @@ private struct ButtonsView: View, Hashable {
         
         self.primaryButtonProvider = primaryButtonProvider
         self.secondaryButtonProvider = secondaryButtonProvider
-        self.colorProvider = colorProvider
     }
     
     var body: some View {
@@ -367,10 +367,10 @@ private struct AccessibilityButtonActionBuilder: ViewModifier {
 }
 
 private struct UnderlinedLinkModifier: ViewModifier {
-    let colorProvider: ColorProvider
-    
+    @Environment(\.warpTheme) private var theme
+
     private var linkColor: Color {
-        colorProvider.token.textLink
+        theme.colors.token.textLink
     }
     
     func body(content: Content) -> some View {

--- a/Sources/Components/Badge/Badge.swift
+++ b/Sources/Components/Badge/Badge.swift
@@ -34,9 +34,14 @@ extension Warp {
         
         /// The corner positioning of the badge.
         private let position: Warp.BadgePosition
-        
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// The object responsible for providing colors to the badge based on the current environment or theme.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         /// Initializes a `Badge` with the given text, optional icon, style, and position.
         ///

--- a/Sources/Components/Box/Box.swift
+++ b/Sources/Components/Box/Box.swift
@@ -31,8 +31,13 @@ extension Warp {
         /// Passing `nil` will skip adding button view.
         let buttonProvider: Warp.Button?
 
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object responsible for providing colors in different environments and variants.
-        let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         public static func == (lhs: Box, rhs: Box) -> Bool {
             let styleComparison = lhs.style == rhs.style
@@ -177,7 +182,7 @@ extension Warp {
                                 style: .caption,
                                 color: colorProvider.token.textLink
                             )
-                            .modifier(UnderlinedLinkModifier(colorProvider: colorProvider))
+                            .modifier(UnderlinedLinkModifier())
                             
                             Spacer()
                         }
@@ -189,10 +194,7 @@ extension Warp {
         }
         
         private var buttonsView: some View {
-            ButtonView(
-                buttonProvider: buttonProvider,
-                colorProvider: colorProvider
-            )
+            ButtonView(buttonProvider: buttonProvider)
         }
     }
 }
@@ -239,26 +241,20 @@ private struct AccessibilityButtonActionBuilder: ViewModifier {
 private struct ButtonView: View, Hashable {
     let buttonProvider: Warp.Button
 
-    let colorProvider: ColorProvider
-    
     static func == (lhs: ButtonView, rhs: ButtonView) -> Bool {
         lhs.buttonProvider == rhs.buttonProvider
     }
-    
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(buttonProvider)
     }
-    
-    init?(
-        buttonProvider: Warp.Button?,
-        colorProvider: ColorProvider
-    ) {
+
+    init?(buttonProvider: Warp.Button?) {
         guard let buttonProvider else {
             return nil
         }
-        
+
         self.buttonProvider = buttonProvider
-        self.colorProvider = colorProvider
     }
     
     var body: some View {
@@ -271,10 +267,10 @@ private struct ButtonView: View, Hashable {
 }
 
 private struct UnderlinedLinkModifier: ViewModifier {
-    let colorProvider: ColorProvider
-    
+    @Environment(\.warpTheme) private var theme
+
     private var linkColor: Color {
-        colorProvider.token.textLink
+        theme.colors.token.textLink
     }
     
     func body(content: Content) -> some View {

--- a/Sources/Components/Broadcast/Broadcast.swift
+++ b/Sources/Components/Broadcast/Broadcast.swift
@@ -34,8 +34,13 @@ extension Warp {
         /// Binding to a boolean value that allows the broadcast to control dismissal
         @Binding public var isPresented: Bool
 
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object responsible for providing colors in different environments and variants.
-        let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         /**
          - Parameter text: String to display in the `Broadcast`

--- a/Sources/Components/Button/Button.swift
+++ b/Sources/Components/Button/Button.swift
@@ -31,8 +31,13 @@ extension Warp {
         /// Flag indicating whether this view is loading.
         private let isLoading: Bool
 
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object that will provide needed colors.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         private var isMultilineAndCentered: Bool = false
 

--- a/Sources/Components/ButtonGroup/ButtonGroup.swift
+++ b/Sources/Components/ButtonGroup/ButtonGroup.swift
@@ -15,8 +15,14 @@ extension Warp {
         @Binding public var buttons: [(title: String, isSelected: Bool)]
         public let onSelectionChange: (([(String, Bool)]) -> Void)?
         public let singleSelect: Bool
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object responsible for providing colors in different environments and variants.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         /// Initializes the ButtonGroup view with an array of buttons, selection mode, and a selection change handler.
         ///

--- a/Sources/Components/ButtonPill/ButtonPill.swift
+++ b/Sources/Components/ButtonPill/ButtonPill.swift
@@ -38,16 +38,9 @@ extension Warp {
             .onLongPressGesture(
                 minimumDuration: 0,
                 pressing: { inProgress in
-//                    withAnimation(.easeIn(duration: 0.1)) {
-                        if inProgress {
-//                            state = .active
-                        } else {
-//                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-//                                state = .default
-//                            }
-                            selected.toggle()
-                        }
-//                    }
+                    if !inProgress {
+                        selected.toggle()
+                    }
                 },
                 perform: {}
             )

--- a/Sources/Components/ButtonPill/ButtonPill.swift
+++ b/Sources/Components/ButtonPill/ButtonPill.swift
@@ -8,7 +8,13 @@ extension Warp {
         private let type: ButtonPillType
         @State private var state: ButtonPillState = .default
         @Binding private var selected: Bool
-        private let colorProvider: ColorProvider = Warp.Color
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         /// Initializes a `ButtonPill` with a given type and selected state.
         /// - Parameters:

--- a/Sources/Components/Callout/Callout.swift
+++ b/Sources/Components/Callout/Callout.swift
@@ -43,8 +43,13 @@ extension Warp {
         /// Corner radius,
         private let cornerRadius: Double
 
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object responsible for providing colors in different environments and variants.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         /**
          - Parameter size: Size of callout, default value is `.default`

--- a/Sources/Components/Checkbox/Checkbox.swift
+++ b/Sources/Components/Checkbox/Checkbox.swift
@@ -23,8 +23,14 @@ extension Warp {
         var extraContent: AnyView?
         /// A closure that is executed when the checkbox is tapped.
         var action: () -> Void
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object that will provide needed colors.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         /// Initializes a new `Checkbox`.
         ///

--- a/Sources/Components/Checkbox/CheckboxGroup.swift
+++ b/Sources/Components/Checkbox/CheckboxGroup.swift
@@ -27,8 +27,14 @@ extension Warp {
         var axis: Axis.Set
         /// A closure that will be triggered when an option is selected, providing the latest selected option and the updated list of options.
         var onSelection: ((Option, [Option]) -> Void)?
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object that will provide needed colors.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         /// Initializes a new `CheckboxGroup`.
         ///

--- a/Sources/Components/DatePicker/DatePicker.swift
+++ b/Sources/Components/DatePicker/DatePicker.swift
@@ -21,6 +21,9 @@ extension Warp {
         /// The range of selectable dates.
         private let range: DatePickerRange?
 
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Initializes a `DatePicker` with a binding to the selected date.
         ///
         /// **Usage:**
@@ -83,7 +86,7 @@ extension Warp {
         public var body: some View {
             nativeDatePicker
             .datePickerStyle(.graphical)
-            .accentColor(Warp.Token.backgroundPrimary)
+            .accentColor(theme.token.backgroundPrimary)
         }
 
         private var nativeDatePicker: some View {

--- a/Sources/Components/Divider/Divider.swift
+++ b/Sources/Components/Divider/Divider.swift
@@ -13,8 +13,15 @@ extension Warp {
     /// Warp.Divider(orientation: .vertical, style: .dashed)
     /// ```
     public struct Divider: View {
-        // MARK: - WARP Style      
-        let color = Warp.Token.border
+        // MARK: - WARP Style
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        private var color: Color {
+            theme.token.border
+        }
+
         let thickness: CGFloat = Warp.Border.borderWidth12
 
         /// Orientation for the divider: horizontal or vertical.

--- a/Sources/Components/Expandable/Expandable.swift
+++ b/Sources/Components/Expandable/Expandable.swift
@@ -34,7 +34,12 @@ extension Warp {
         let style: Warp.ExpandableStyle
         let isAnimated: Bool
 
-        let colorProvider: ColorProvider = Warp.Color
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         public init(
             style: Warp.ExpandableStyle,
@@ -130,7 +135,13 @@ public extension Warp {
      */
     struct ExpandableStringWrapperView: View {
         let subtitle: String
-        let colorProvider: ColorProvider = Warp.Color
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         public var body: some View {
             VStack(spacing: 0) {

--- a/Sources/Components/HelpText/HelpText.swift
+++ b/Sources/Components/HelpText/HelpText.swift
@@ -19,14 +19,19 @@ extension Warp {
 
         // MARK: - Properties
 
-        /// Object responsible for providing colors in different environments and variants.
-        private let colorProvider: ColorProvider = Warp.Color
-
         /// The text to display.
         private let text: String
 
         /// The style to apply to the text.
         private let style: Warp.HelpTextStyle
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        /// Object responsible for providing colors in different environments and variants.
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         // MARK: - Initialization
 

--- a/Sources/Components/IconView/IconView.swift
+++ b/Sources/Components/IconView/IconView.swift
@@ -9,19 +9,21 @@ extension Warp {
         private let icon: Warp.Icon
         /// The size of the icon (small, default, large, or custom). Default is `.default`.
         private let size: Warp.IconSize
-        /// The color of the icon. Defaults to `Warp.Color.token.icon`.
-        private let color: Color
-        private let colorProvider: ColorProvider = Warp.Color
+        /// The color of the icon. If nil, defaults to theme's icon color.
+        private let color: Color?
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
         
         /// Initializes a new `IconView`.
         ///
         /// - Parameters:
         ///   - icon: The `Warp.Icon` to display.
         ///   - size: The size of the icon (small, default, large, or custom). Default is `.default`.
-        ///   - color: The color of the icon. Defaults to `Warp.Token.icon`.
+        ///   - color: The color of the icon. If nil, uses the theme's default icon color.
         public init(_ icon: Warp.Icon,
                     size: Warp.IconSize = .default,
-                    color: Color = Warp.Token.icon) {
+                    color: Color? = nil) {
             self.icon = icon
             self.size = size
             self.color = color
@@ -30,7 +32,7 @@ extension Warp {
         public var body: some View {
             icon
                 .frame(width: size.value, height: size.value)
-                .foregroundColor(color) // Apply the icon color
+                .foregroundColor(color ?? theme.token.icon) // Apply the icon color
         }
     }
 }
@@ -46,13 +48,21 @@ extension Warp.IconView {
 }
 
 #Preview {
-    ScrollView(showsIndicators: false) {
-        // Example preview displaying multiple icons with different sizes and colors
-        VStack(spacing: 20) {
-            Warp.IconView(.activeAds, size: .small, color: Warp.Token.iconPrimary)
-            Warp.IconView(.ads, size: .default, color: Warp.Token.iconWarning)
-            Warp.IconView(.airCon, size: .large, color: Warp.Token.iconNegative)
+    PreviewWrapper()
+}
+
+private struct PreviewWrapper: View {
+    @Environment(\.warpTheme) private var theme
+
+    var body: some View {
+        ScrollView(showsIndicators: false) {
+            // Example preview displaying multiple icons with different sizes and colors
+            VStack(spacing: 20) {
+                Warp.IconView(.activeAds, size: .small, color: theme.token.iconPrimary)
+                Warp.IconView(.ads, size: .default, color: theme.token.iconWarning)
+                Warp.IconView(.airCon, size: .large, color: theme.token.iconNegative)
+            }
+            .padding()
         }
-        .padding()
     }
 }

--- a/Sources/Components/Label/Label.swift
+++ b/Sources/Components/Label/Label.swift
@@ -23,11 +23,16 @@ extension Warp {
 
         // MARK: - Properties
 
-        /// Object responsible for providing colors in different environments and variants.
-        private let colorProvider: ColorProvider = Warp.Color
-
         /// State variable to manage the presentation of the tooltip content.
         @State private var isTooltipPresented: Bool = false
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        /// Object responsible for providing colors in different environments and variants.
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         /// The main title text to display.
         private let title: String

--- a/Sources/Components/Modal/Modal.swift
+++ b/Sources/Components/Modal/Modal.swift
@@ -30,9 +30,14 @@ extension Warp {
         
         /// A binding to control the visibility of the modal.
         @Binding var isPresented: Bool
-        
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object responsible for providing colors in different environments and variants.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         // MARK: - Initializer
         

--- a/Sources/Components/Modal/ModalViewModifier.swift
+++ b/Sources/Components/Modal/ModalViewModifier.swift
@@ -79,7 +79,7 @@ extension Warp {
                     .disabled(isPresented)
                     .fullScreenCover(isPresented: $isPresented) {
                         warpModalOverlay()
-                            .background(TransparentBackground())
+                          .presentationBackground(.clear)
                     }
                     .transaction { transaction in
                         transaction.disablesAnimations = true
@@ -111,31 +111,6 @@ extension Warp {
                 .edgesIgnoringSafeArea(.all)
                 .ignoresSafeArea(edges: .all)
             }
-        }
-    }
-}
-
-/// A workaround to make fullScreenCover backgrounds transparent on iOS 15.
-///
-/// iOS 16.4+ can use `.presentationBackground(.clear)` instead.
-/// This UIKit-based approach walks the view hierarchy to clear the hosting controller's background.
-///
-/// - Note: This is a known limitation of `.fullScreenCover` in iOS 15, where SwiftUI doesn't provide
-///   a native way to make the presentation background transparent.
-@MainActor
-struct TransparentBackground: UIViewRepresentable {
-    func makeUIView(context: Context) -> UIView {
-        return UIView()
-    }
-
-    func updateUIView(_ uiView: UIView, context: Context) {
-        // Clear the background after the view is in the hierarchy.
-        // The superview hierarchy is: UIView -> UITransitionView -> UIHostingController.view
-        DispatchQueue.main.async {
-            guard let superview = uiView.superview?.superview else {
-                return
-            }
-            superview.backgroundColor = .clear
         }
     }
 }

--- a/Sources/Components/Modal/ModalViewModifier.swift
+++ b/Sources/Components/Modal/ModalViewModifier.swift
@@ -115,16 +115,29 @@ extension Warp {
     }
 }
 
+/// A workaround to make fullScreenCover backgrounds transparent on iOS 15.
+///
+/// iOS 16.4+ can use `.presentationBackground(.clear)` instead.
+/// This UIKit-based approach walks the view hierarchy to clear the hosting controller's background.
+///
+/// - Note: This is a known limitation of `.fullScreenCover` in iOS 15, where SwiftUI doesn't provide
+///   a native way to make the presentation background transparent.
+@MainActor
 struct TransparentBackground: UIViewRepresentable {
     func makeUIView(context: Context) -> UIView {
-        let view = UIView()
-        DispatchQueue.main.async {
-            view.superview?.superview?.backgroundColor = .clear
-        }
-        return view
+        return UIView()
     }
-    
-    func updateUIView(_ uiView: UIView, context: Context) {}
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        // Clear the background after the view is in the hierarchy.
+        // The superview hierarchy is: UIView -> UITransitionView -> UIHostingController.view
+        DispatchQueue.main.async {
+            guard let superview = uiView.superview?.superview else {
+                return
+            }
+            superview.backgroundColor = .clear
+        }
+    }
 }
 
 public extension View {

--- a/Sources/Components/PageIndicator/PageIndicator.swift
+++ b/Sources/Components/PageIndicator/PageIndicator.swift
@@ -25,9 +25,14 @@ extension Warp {
         
         /// Binding to an integer representing the currently selected page.
         @Binding private var selectedPage: Int
-        
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object responsible for providing colors in different environments and variants.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         // MARK: - Initialization
         

--- a/Sources/Components/Pill/Pill.swift
+++ b/Sources/Components/Pill/Pill.swift
@@ -25,8 +25,14 @@ extension Warp {
         private let iconContentDescription: String?
         /// Pill style.
         private let style: Warp.PillStyle
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object that will provide needed colors.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         public init(
             text: String,

--- a/Sources/Components/Radio/Radio.swift
+++ b/Sources/Components/Radio/Radio.swift
@@ -23,8 +23,14 @@ extension Warp {
         var extraContent: AnyView?
         /// A closure that is executed when the radio button is tapped.
         var action: () -> Void
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object that will provide needed colors.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         /// Initializes a new `Radio`.
         ///

--- a/Sources/Components/Radio/RadioGroup.swift
+++ b/Sources/Components/Radio/RadioGroup.swift
@@ -30,8 +30,14 @@ extension Warp {
         var axis: Axis.Set
         /// A closure that will be triggered when an option is selected, providing the old and new selection.
         var onSelection: ((Option, Option) -> Void)?
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object that will provide needed colors.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         /// Initializes a new `RadioGroup`.
         ///

--- a/Sources/Components/RangeSlider/RangeSlider.swift
+++ b/Sources/Components/RangeSlider/RangeSlider.swift
@@ -31,16 +31,40 @@ extension Warp {
     public struct RangeSlider: View {
         
         public typealias Element = Double // Could be generic, just in case...
-        
+
         // Constants for styling
         private let thumbDiameter: CGFloat = 28 + 16 // 16 for the active border
-        private let trackColor = Warp.Token.backgroundDisabledSubtle
-        private let filledTrackColor = Warp.Token.backgroundPrimary
-        private let thumbColor = Warp.Token.backgroundPrimary
-        private let thumbBorderColor = Warp.Token.backgroundDisabled.opacity(0.4)
-        private let thumbActiveColor = Warp.Token.backgroundPrimaryActive
-        private let textIndicatorColor = Warp.Token.textSubtle
-        private let disabledColor = Warp.Token.backgroundDisabled
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        private var trackColor: Color {
+            theme.token.backgroundDisabledSubtle
+        }
+
+        private var filledTrackColor: Color {
+            theme.token.backgroundPrimary
+        }
+
+        private var thumbColor: Color {
+            theme.token.backgroundPrimary
+        }
+
+        private var thumbBorderColor: Color {
+            theme.token.backgroundDisabled.opacity(0.4)
+        }
+
+        private var thumbActiveColor: Color {
+            theme.token.backgroundPrimaryActive
+        }
+
+        private var textIndicatorColor: Color {
+            theme.token.textSubtle
+        }
+
+        private var disabledColor: Color {
+            theme.token.backgroundDisabled
+        }
 
         @Binding var range: ClosedRange<Element>  // Binding range to update the slider range
         let bounds: ClosedRange<Element>  // Defines the bounds for the slider

--- a/Sources/Components/Select/Select.swift
+++ b/Sources/Components/Select/Select.swift
@@ -20,10 +20,15 @@ extension Warp {
     /// Warning: The options array should not be empty to ensure proper functionality.
     public struct Select: View {
 
-        /// Object responsible for providing colors in different environments and variants.
-        private let colorProvider: ColorProvider = Warp.Color
-
         @Binding private var selectedOption: Warp.Select.SelectorOption?
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        /// Object responsible for providing colors in different environments and variants.
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         private let options: [Warp.Select.SelectorOption]
         private let title: String
         private let additionalInformation: String?

--- a/Sources/Components/Slider/Slider.swift
+++ b/Sources/Components/Slider/Slider.swift
@@ -22,13 +22,37 @@ extension Warp {
         // Constants for styling
         private let thumbDiameter: CGFloat = 28 + 16 // 16 for the active border
         private let cornerRadius = Warp.Border.borderRadius50
-        private let trackColor = Warp.Token.backgroundDisabledSubtle
-        private let filledTrackColor = Warp.Token.backgroundPrimary
-        private let thumbColor = Warp.Token.backgroundPrimary
-        private let thumbBorderColor = Warp.Token.backgroundDisabled.opacity(0.4)
-        private let thumbActiveColor = Warp.Token.backgroundPrimaryActive
-        private let textIndicatorColor = Warp.Token.textSubtle
-        private let disabledColor = Warp.Token.backgroundDisabled
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        private var trackColor: Color {
+            theme.token.backgroundDisabledSubtle
+        }
+
+        private var filledTrackColor: Color {
+            theme.token.backgroundPrimary
+        }
+
+        private var thumbColor: Color {
+            theme.token.backgroundPrimary
+        }
+
+        private var thumbBorderColor: Color {
+            theme.token.backgroundDisabled.opacity(0.4)
+        }
+
+        private var thumbActiveColor: Color {
+            theme.token.backgroundPrimaryActive
+        }
+
+        private var textIndicatorColor: Color {
+            theme.token.textSubtle
+        }
+
+        private var disabledColor: Color {
+            theme.token.backgroundDisabled
+        }
 
         @Binding var value: Double // Binding value to update the slider value
         let range: ClosedRange<Double> // Defines the range for the slider

--- a/Sources/Components/Spinner/Spinner.swift
+++ b/Sources/Components/Spinner/Spinner.swift
@@ -48,25 +48,23 @@ extension Warp {
                     .frame(width: size.value, height: size.value)
                     .foregroundColor(colorProvider.token.borderPrimary)
                     .onAppear() {
-                        DispatchQueue.main.async {
-                            withAnimation(Animation
-                                .linear(duration: duration)
-                                .repeatForever(autoreverses: false)) {
-                                    self.isCircleRotating.toggle()
-                                }
-                            withAnimation(Animation
-                                .linear(duration: duration)
-                                .delay(0.5)
-                                .repeatForever(autoreverses: true)) {
-                                    self.animateStart.toggle()
-                                }
-                            withAnimation(Animation
-                                .linear(duration: duration)
-                                .delay(1)
-                                .repeatForever(autoreverses: true)) {
-                                    self.animateEnd.toggle()
-                                }
-                        }
+                        withAnimation(Animation
+                            .linear(duration: duration)
+                            .repeatForever(autoreverses: false)) {
+                                self.isCircleRotating.toggle()
+                            }
+                        withAnimation(Animation
+                            .linear(duration: duration)
+                            .delay(0.5)
+                            .repeatForever(autoreverses: true)) {
+                                self.animateStart.toggle()
+                            }
+                        withAnimation(Animation
+                            .linear(duration: duration)
+                            .delay(1)
+                            .repeatForever(autoreverses: true)) {
+                                self.animateEnd.toggle()
+                            }
                     }
             }
         }

--- a/Sources/Components/Spinner/Spinner.swift
+++ b/Sources/Components/Spinner/Spinner.swift
@@ -14,15 +14,21 @@ extension Warp {
         @State private var isCircleRotating = true
         @State private var animateStart = false
         @State private var animateEnd = true
-        
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        /// Object responsible for providing colors in different environments and variants.
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
+
         /// Size of the spinner
         private let size: SpinnerSize
         /// Duration of animation
         private let duration: CGFloat
         /// Line width of the spinner
         private let lineWidth: CGFloat
-        /// Object that will provide needed colors.
-        private let colorProvider: ColorProvider = Warp.Color
         
         public init(
             size: SpinnerSize = .default,

--- a/Sources/Components/StepIndicator/StepIndicator.swift
+++ b/Sources/Components/StepIndicator/StepIndicator.swift
@@ -14,7 +14,6 @@ extension Warp {
 
         - A `Warp.StepIndicator.LayoutOrientation`. **Optional:** _default is `.vertical` if none is specified_.
         - An array of `Warp.StepIndicatorItem`s.
-        - A `ColorProvider`. **Optional:** _default is read from `Warp.Color` if none is specified_.
 
      */
     public struct StepIndicator: View {
@@ -26,7 +25,13 @@ extension Warp {
 
         let layoutOrientation: LayoutOrientation
 
-        let colorProvider: ColorProvider = Warp.Color
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        /// Object responsible for providing colors in different environments and variants.
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         private let orderedSteps: [StepIndicatorModel.OrderedStepIndicatorItem]
 

--- a/Sources/Components/StepIndicator/Subviews/DescriptionView.swift
+++ b/Sources/Components/StepIndicator/Subviews/DescriptionView.swift
@@ -6,19 +6,24 @@ extension Warp.StepIndicator {
         let description: String
         let layoutOrientation: LayoutOrientation
         let progress: Warp.StepIndicatorItem.Progress
-        let colorProvider: ColorProvider
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        /// Object responsible for providing colors in different environments and variants.
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         init(
             step: Warp.StepIndicatorItem,
-            layoutOrientation: LayoutOrientation,
-            colorProvider: ColorProvider = Warp.Color
+            layoutOrientation: LayoutOrientation
         ) {
             self.init(
                 title: step.title,
                 description: step.description,
                 layoutOrientation: layoutOrientation,
-                progress: step.progress,
-                colorProvider: colorProvider
+                progress: step.progress
             )
         }
 
@@ -26,14 +31,12 @@ extension Warp.StepIndicator {
             title: String,
             description: String,
             layoutOrientation: LayoutOrientation,
-            progress: Warp.StepIndicatorItem.Progress,
-            colorProvider: ColorProvider = Warp.Color
+            progress: Warp.StepIndicatorItem.Progress
         ) {
             self.title = title
             self.description = description
             self.layoutOrientation = layoutOrientation
             self.progress = progress
-            self.colorProvider = colorProvider
         }
 
         var body: some View {

--- a/Sources/Components/StepIndicator/Subviews/HorizontalProgressView.swift
+++ b/Sources/Components/StepIndicator/Subviews/HorizontalProgressView.swift
@@ -2,17 +2,22 @@ import SwiftUI
 
 extension Warp.StepIndicator {
     struct HorizontalProgressView: View {
-        let colorProvider: ColorProvider
         let progress: Warp.StepIndicatorItem.Progress
         let stepPosition: Warp.StepIndicatorItem.Position
         let lineHeight: Double = 2
 
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        /// Object responsible for providing colors in different environments and variants.
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
+
         init(
-            colorProvider: ColorProvider = Warp.Color,
             progress: Warp.StepIndicatorItem.Progress,
             stepPosition: Warp.StepIndicatorItem.Position
         ) {
-            self.colorProvider = colorProvider
             self.progress = progress
             self.stepPosition = stepPosition
         }
@@ -64,12 +69,14 @@ extension Warp.StepIndicator {
                 Warp.StepIndicator.LineBuilder.line(
                     for: previousProgress,
                     ownProgress: progress,
+                    colorProvider: colorProvider,
                     orientation: .horizontal
                 )
             case .last(let previousProgress):
                 Warp.StepIndicator.LineBuilder.line(
                     for: previousProgress,
                     ownProgress: progress,
+                    colorProvider: colorProvider,
                     orientation: .horizontal
                 )
             }
@@ -83,6 +90,7 @@ extension Warp.StepIndicator {
                     Warp.StepIndicator.LineBuilder.line(
                         for: nextProgress,
                         ownProgress: progress,
+                        colorProvider: colorProvider,
                         orientation: .horizontal
                     )
                 } else {
@@ -92,6 +100,7 @@ extension Warp.StepIndicator {
                 Warp.StepIndicator.LineBuilder.line(
                     for: nextProgress,
                     ownProgress: progress,
+                    colorProvider: colorProvider,
                     orientation: .horizontal
                 )
             case .last:

--- a/Sources/Components/StepIndicator/Subviews/VerticalProgressView.swift
+++ b/Sources/Components/StepIndicator/Subviews/VerticalProgressView.swift
@@ -2,17 +2,22 @@ import SwiftUI
 
 extension Warp.StepIndicator {
     struct VerticalProgressView: View {
-        let colorProvider: ColorProvider
         let progress: Warp.StepIndicatorItem.Progress
         let stepPosition: Warp.StepIndicatorItem.Position
         let lineWidth: Double = 2
-        
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        /// Object responsible for providing colors in different environments and variants.
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
+
         init(
-            colorProvider: ColorProvider = Warp.Color,
             progress: Warp.StepIndicatorItem.Progress,
             stepPosition: Warp.StepIndicatorItem.Position
         ) {
-            self.colorProvider = colorProvider
             self.progress = progress
             self.stepPosition = stepPosition
         }
@@ -54,6 +59,7 @@ extension Warp.StepIndicator {
                     LineBuilder.line(
                         for: nextProgress,
                         ownProgress: progress,
+                        colorProvider: colorProvider,
                         orientation: .vertical
                     )
                 } else {
@@ -63,6 +69,7 @@ extension Warp.StepIndicator {
                 LineBuilder.line(
                     for: nextProgress,
                     ownProgress: progress,
+                    colorProvider: colorProvider,
                     orientation: .vertical
                 )
             case .last:

--- a/Sources/Components/StepIndicator/ViewHelpers/LineBuilder.swift
+++ b/Sources/Components/StepIndicator/ViewHelpers/LineBuilder.swift
@@ -6,7 +6,7 @@ extension Warp.StepIndicator {
         static func line(
             for otherProgress: Warp.StepIndicatorItem.Progress,
             ownProgress: Warp.StepIndicatorItem.Progress,
-            colorProvider: ColorProvider = Warp.Color,
+            colorProvider: ColorProvider,
             orientation: Warp.StepIndicator.LayoutOrientation,
             lineThickness: Double = 2
         ) -> some View {

--- a/Sources/Components/Switch/Switch.swift
+++ b/Sources/Components/Switch/Switch.swift
@@ -19,13 +19,18 @@ extension Warp {
     public struct Switch: View {
         
         // MARK: - Properties
-        
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object responsible for providing colors in different environments and variants.
-        private let colorProvider: ColorProvider = Warp.Color
-        
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
+
         /// Binding to a Boolean value indicating whether the switch is on or off.
         @Binding private var isOn: Bool
-        
+
         /// The state of the switch.
         private let state: Warp.SwitchState
         

--- a/Sources/Components/Tabs/TabItem.swift
+++ b/Sources/Components/Tabs/TabItem.swift
@@ -21,7 +21,14 @@ extension Warp {
         let title: String
         let icon: Warp.Icon?
         let isSelected: Bool
-        private let colorProvider: ColorProvider = Warp.Color
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        /// Object responsible for providing colors in different environments and variants.
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         public var body: some View {
             HStack(alignment: .center, spacing: Warp.Spacing.spacing100) {

--- a/Sources/Components/Tabs/Tabs.swift
+++ b/Sources/Components/Tabs/Tabs.swift
@@ -13,7 +13,14 @@ extension Warp {
         public let tabs: [TabItem]
         @Binding private var selectedIndex: Int
         private let isScrollable: Bool
-        private let colorProvider: ColorProvider = Warp.Color
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        /// Object responsible for providing colors in different environments and variants.
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
         
         /// Initializes the Tabs view with an array of tabs and a binding for the selected index.
         ///

--- a/Sources/Components/Text/Text.swift
+++ b/Sources/Components/Text/Text.swift
@@ -17,25 +17,34 @@ extension Warp {
         private let text: String
         /// The style applied to the text, determining its typography and appearance.
         private let style: Warp.TextStyle
-        /// The foreground style of the text, which can be a solid color, gradient, or other shape style.
-        private let foregroundStyle: AnyShapeStyle
-        /// Provides color tokens for the Warp design system.
-        private let colorProvider: ColorProvider = Warp.Color
+        /// The optional color for the text.
+        private let color: Color?
+        /// The optional custom foreground style for the text.
+        private let customForegroundStyle: AnyShapeStyle?
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
+        /// Object responsible for providing colors in different environments and variants.
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         /// Initializes a Warp.Text view with specific text, style, and a single color.
         ///
         /// - Parameters:
         ///   - text: The text content to display.
         ///   - style: The text style, defined by `Warp.TextStyle`, which determines typography and size.
-        ///   - color: A solid color for the text. Defaults to `Warp.Token.text`.
+        ///   - color: An optional solid color for the text. Defaults to nil, which uses the theme's default text color.
         public init(
             _ text: String,
             style: Warp.TextStyle,
-            color: Color = Warp.Token.text
+            color: Color? = nil
         ) {
             self.text = text
             self.style = style
-            self.foregroundStyle = AnyShapeStyle(color)
+            self.color = color
+            self.customForegroundStyle = nil
         }
 
         /// Initializes a Warp.Text view with specific text, style, and a custom foreground style.
@@ -51,13 +60,22 @@ extension Warp {
         ) {
             self.text = text
             self.style = style
-            self.foregroundStyle = foregroundStyle
+            self.color = nil
+            self.customForegroundStyle = foregroundStyle
         }
 
         public var body: some View {
-            SwiftUI.Text(text)
+            let resolvedStyle: AnyShapeStyle
+            if let customForegroundStyle {
+                resolvedStyle = customForegroundStyle
+            } else {
+                let resolvedColor = color ?? theme.token.text
+                resolvedStyle = AnyShapeStyle(resolvedColor)
+            }
+
+            return SwiftUI.Text(text)
                 .font(from: style.asTypography)
-                .foregroundStyle(foregroundStyle)
+                .foregroundStyle(resolvedStyle)
         }
     }
 }

--- a/Sources/Components/TextArea/TextArea.swift
+++ b/Sources/Components/TextArea/TextArea.swift
@@ -29,9 +29,14 @@ extension Warp {
     public struct TextArea: View {
         
         // MARK: - Properties
-        
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object responsible for providing colors in different environments and variants.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         /// The corner radius for the text area border.
         private let cornerRadius = Warp.Border.borderRadius50

--- a/Sources/Components/TextField/TextField.swift
+++ b/Sources/Components/TextField/TextField.swift
@@ -33,8 +33,13 @@ extension Warp {
 
         // MARK: - Properties
 
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object responsible for providing colors in different environments and variants.
-        private let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         /// The corner radius for the text field border.
         private let cornerRadius = Warp.Border.borderRadius50

--- a/Sources/Components/Toast/Toast.swift
+++ b/Sources/Components/Toast/Toast.swift
@@ -34,8 +34,13 @@ extension Warp {
         /// Binding to a boolean value that allows the toast to control dismissal
         @Binding public var isPresented: Bool
 
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object responsible for providing colors in different environments and variants.
-        let colorProvider: ColorProvider = Warp.Color
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
 
         private let showCloseButton: Bool
 

--- a/Sources/Components/Tooltip/Tooltip.swift
+++ b/Sources/Components/Tooltip/Tooltip.swift
@@ -22,10 +22,15 @@ extension Warp {
 
         /// Custom arrow offset from top/leading edge
         private var arrowOffset: CGFloat?
-        
+
+        /// The current theme from the environment.
+        @Environment(\.warpTheme) private var theme
+
         /// Object responsible for providing colors in different environments and variants.
-        private let colorProvider: ColorProvider = Warp.Color
-        
+        private var colorProvider: ColorProvider {
+            theme.colors
+        }
+
         /// Constants to create the view
         private let arrowHeight: CGFloat = 8
         private let arrowWidth: CGFloat = 18

--- a/Sources/Environment/WarpThemeEnvironment.swift
+++ b/Sources/Environment/WarpThemeEnvironment.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// This replaces the global `Warp.Theme` variable with a proper environment-based system
 /// that is Swift 6 concurrency-safe and testable.
 struct WarpThemeKey: EnvironmentKey {
-    static let defaultValue: Warp.Brand = .finn
+    static let defaultValue: Warp.Brand = Warp.Theme // Default to the global theme for backward compatibility, remove in future versions
 }
 
 extension EnvironmentValues {

--- a/Sources/Environment/WarpThemeEnvironment.swift
+++ b/Sources/Environment/WarpThemeEnvironment.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+// MARK: - Environment Key
+
+/// Environment key for injecting the Warp theme throughout the view hierarchy.
+///
+/// This replaces the global `Warp.Theme` variable with a proper environment-based system
+/// that is Swift 6 concurrency-safe and testable.
+struct WarpThemeKey: EnvironmentKey {
+    static let defaultValue: Warp.Brand = .finn
+}
+
+extension EnvironmentValues {
+    /// The current Warp theme for the view hierarchy.
+    ///
+    /// Use this instead of the global `Warp.Theme` variable:
+    /// ```swift
+    /// struct MyView: View {
+    ///     @Environment(\.warpTheme) private var theme
+    ///
+    ///     var body: some View {
+    ///         Text("Hello")
+    ///             .foregroundColor(ColorProvider(theme: theme).textPrimary)
+    ///     }
+    /// }
+    /// ```
+    public var warpTheme: Warp.Brand {
+        get { self[WarpThemeKey.self] }
+        set { self[WarpThemeKey.self] = newValue }
+    }
+}
+
+// MARK: - View Extension
+
+public extension View {
+    /// Sets the Warp theme for this view and all its descendants.
+    ///
+    /// - Parameter theme: The brand theme to apply
+    /// - Returns: A view with the theme set in its environment
+    ///
+    /// Example:
+    /// ```swift
+    /// ContentView()
+    ///     .warpTheme(.finn)
+    /// ```
+    func warpTheme(_ theme: Warp.Brand) -> some View {
+        environment(\.warpTheme, theme)
+    }
+}

--- a/Sources/Icon/Icon.swift
+++ b/Sources/Icon/Icon.swift
@@ -834,7 +834,7 @@ extension Warp {
                 size == .default ? "tori" : "toriSmall"
             case .vend(let size):
                 size == .default ? "vend" : "vendSmall"
-            case .vendPro(let size):
+            case .vendPro(_):
                 "vendPro" // VendPro only has one size
             }
         }

--- a/Sources/Patterns/StateViews/StateView.swift
+++ b/Sources/Patterns/StateViews/StateView.swift
@@ -46,6 +46,14 @@ public struct StateView: View {
 
     private let configuration: StateViewConfiguration
 
+    /// The current theme from the environment.
+    @Environment(\.warpTheme) private var theme
+
+    /// Object responsible for providing colors in different environments and variants.
+    private var colorProvider: ColorProvider {
+        theme.colors
+    }
+
     /// Initializes a `StateView` with the provided configuration parameters.
     ///
     /// - Parameters:
@@ -98,7 +106,7 @@ public struct StateView: View {
             Warp.IconView(
                 icon,
                 size: .custom(configuration.imageWidth ?? 64),
-                color: Warp.Token.iconPrimary
+                color: theme.token.iconPrimary
             )
         case .illustration(let illustration):
             illustration

--- a/Sources/Previews/ThemePreviewModifier.swift
+++ b/Sources/Previews/ThemePreviewModifier.swift
@@ -1,31 +1,36 @@
 import SwiftUI
 
-/// A preview modifier that sets the Warp theme in the preview.
+/// A preview modifier that sets the Warp theme in the preview using environment injection.
 ///
-/// Usage: `#Preview(traits: .themeFinn)`
+/// Usage: `#Preview(traits: .themeFinn) { MyView() }`
 struct ThemePreviewModifier: PreviewModifier {
-    init(theme: Warp.Brand) {
-        Warp.Theme = theme
-    }
+    let theme: Warp.Brand
 
     static func makeSharedContext() async throws -> Void {}
 
     func body(content: Content, context: Void) -> some View {
         content
+            .warpTheme(theme)
     }
  }
 
 @available(iOS 18.0, *)
 public extension PreviewTrait where T == Preview.ViewTraits {
-    /// Preview modifier that sets the Blocket Warp theme.
+    /// Preview modifier that sets the Blocket Warp theme via environment.
     static let themeBlocket = PreviewTrait.modifier(ThemePreviewModifier(theme: .blocket))
 
-    /// Preview modifier that sets the DBA Warp theme.
+    /// Preview modifier that sets the DBA Warp theme via environment.
     static let themeDba = PreviewTrait.modifier(ThemePreviewModifier(theme: .dba))
 
-    /// Preview modifier that sets the FINN Warp theme.
+    /// Preview modifier that sets the FINN Warp theme via environment.
     static let themeFinn = PreviewTrait.modifier(ThemePreviewModifier(theme: .finn))
 
-    /// Preview modifier that sets the Tori Warp theme.
+    /// Preview modifier that sets the Tori Warp theme via environment.
     static let themeTori = PreviewTrait.modifier(ThemePreviewModifier(theme: .tori))
+
+    /// Preview modifier that sets the Vend Warp theme via environment.
+    static let themeVend = PreviewTrait.modifier(ThemePreviewModifier(theme: .vend))
+
+    /// Preview modifier that sets the Neutral Warp theme via environment.
+    static let themeNeutral = PreviewTrait.modifier(ThemePreviewModifier(theme: .neutral))
 }

--- a/Sources/Typography/Font.swift
+++ b/Sources/Typography/Font.swift
@@ -75,11 +75,12 @@ extension Warp {
         }
         
         // MARK: - Fonts for Themes
-        /// Returns an array of fonts that should be registered based on the current theme.
+        /// Returns an array of fonts that should be registered for a given theme.
         ///
-        /// This property selects the appropriate fonts based on the active `Warp.Theme`.
-        static var fontForTheme: [Font] {
-            switch Theme {
+        /// - Parameter theme: The brand theme to get fonts for
+        /// - Returns: Array of fonts for the specified theme
+        static func fonts(for theme: Warp.Brand) -> [Font] {
+            switch theme {
             case .finn:
                 return [.finnLight, .finnLightItalic, .finnMedium]
             case .tori:
@@ -93,6 +94,14 @@ extension Warp {
             case .neutral:
                 return [.neutralRegular, .neutralSemiBold]
             }
+        }
+
+        /// Returns an array of fonts that should be registered based on the current global theme.
+        ///
+        /// - Warning: This uses the global `Warp.Theme` variable. Consider using `fonts(for:)` with an explicit theme instead.
+        @available(*, deprecated, message: "Use fonts(for:) with explicit theme parameter instead of global Warp.Theme")
+        static var fontForTheme: [Font] {
+            fonts(for: Warp.Theme)
         }
     }
 }

--- a/Sources/Typography/Typography+Register.swift
+++ b/Sources/Typography/Typography+Register.swift
@@ -2,16 +2,29 @@ import Foundation
 import UIKit
 
 extension Warp.Typography {
-    /// Registers custom fonts associated with the current theme.
+    /// Registers custom fonts for a specific theme.
+    ///
+    /// This method attempts to register each custom font for the specified theme.
+    /// If any font registration fails, the error is thrown, and font registration stops.
+    ///
+    /// - Parameter theme: The brand theme whose fonts should be registered
+    /// - Throws: A `Warp.FontRegistrationError` if the registration of any font fails.
+    public static func registerFonts(for theme: Warp.Brand) throws {
+        try Warp.Font.fonts(for: theme).forEach {
+            try registerFont($0)
+        }
+    }
+
+    /// Registers custom fonts associated with the current global theme.
     ///
     /// This method attempts to register each custom font defined in `Warp.Font.fontForTheme`.
     /// If any font registration fails, the error is thrown, and font registration stops.
     ///
+    /// - Warning: This uses the global `Warp.Theme` variable. Consider using `registerFonts(for:)` with an explicit theme instead.
     /// - Throws: A `Warp.FontRegistrationError` if the registration of any font fails.
+    @available(*, deprecated, message: "Use registerFonts(for:) with explicit theme parameter instead of global Warp.Theme")
     public static func registerFonts() throws {
-        try Warp.Font.fontForTheme.forEach {
-            try registerFont($0)
-        }
+        try registerFonts(for: Warp.Theme)
     }
 
     /// Registers a custom font.

--- a/Sources/Typography/Typography+Register.swift
+++ b/Sources/Typography/Typography+Register.swift
@@ -22,7 +22,6 @@ extension Warp.Typography {
     ///
     /// - Warning: This uses the global `Warp.Theme` variable. Consider using `registerFonts(for:)` with an explicit theme instead.
     /// - Throws: A `Warp.FontRegistrationError` if the registration of any font fails.
-    @available(*, deprecated, message: "Use registerFonts(for:) with explicit theme parameter instead of global Warp.Theme")
     public static func registerFonts() throws {
         try registerFonts(for: Warp.Theme)
     }

--- a/Sources/Warp.swift
+++ b/Sources/Warp.swift
@@ -108,16 +108,22 @@ public enum Warp {
     ///
     /// This computed property returns an instance of a `ColorProvider` initialized with the current theme tokens.
     /// It facilitates easy access to brand-specific colors that are used throughout the design system.
+    ///
+    /// - Warning: This uses the global `Warp.Theme` variable. Consider using `ColorProvider(theme:)` with `@Environment(\.warpTheme)` instead.
+    @available(*, deprecated, message: "Use @Environment(\\.warpTheme) and ColorProvider(theme:) instead of global Warp.Color")
     public static var Color: ColorProvider {
-        ColorProvider(token: Warp.Token)
+        ColorProvider(theme: Warp.Theme)
     }
-    
+
     /// Provides `UIColor` values based on the current theme UITokens.
     ///
     /// This computed property returns an instance of a `UIColorProvider` initialized with the current theme UITokens.
     /// It facilitates easy access to brand-specific UIColors that are used throughout the design system.
+    ///
+    /// - Warning: This uses the global `Warp.Theme` variable. Consider using `UIColorProvider(theme:)` with `@Environment(\.warpTheme)` instead.
+    @available(*, deprecated, message: "Use @Environment(\\.warpTheme) and UIColorProvider(theme:) instead of global Warp.UIColor")
     public static var UIColor: UIColorProvider {
-        UIColorProvider(token: Warp.UIToken)
+        UIColorProvider(theme: Warp.Theme)
     }
 
     // MARK: - Dataviz Token Providers

--- a/Sources/Warp.swift
+++ b/Sources/Warp.swift
@@ -36,6 +36,68 @@ public enum Warp {
                 return "Neutral"
             }
         }
+
+        // MARK: - Provider Access
+
+        /// Color provider for SwiftUI colors
+        var colors: ColorProvider {
+            ColorProvider(theme: self)
+        }
+
+        /// Color provider for UIKit colors
+        var uiColors: UIColorProvider {
+            UIColorProvider(theme: self)
+        }
+
+        /// Semantic token provider for SwiftUI
+        var token: TokenProvider {
+            switch self {
+            case .finn: return FinnTokenProvider()
+            case .tori: return ToriTokenProvider()
+            case .dba: return DbaTokenProvider()
+            case .blocket: return BlocketTokenProvider()
+            case .vend: return VendTokenProvider()
+            case .neutral: return NeutralTokenProvider()
+            }
+        }
+
+        /// Semantic token provider for UIKit
+        var uiToken: UITokenProvider {
+            switch self {
+            case .finn: return FinnUITokenProvider()
+            case .tori: return ToriUITokenProvider()
+            case .dba: return DbaUITokenProvider()
+            case .blocket: return BlocketUITokenProvider()
+            case .vend: return VendUITokenProvider()
+            case .neutral: return NeutralUITokenProvider()
+            }
+        }
+
+        /// Data visualization token provider
+        var datavizToken: DatavizTokenProvider {
+            DatavizTokenProvider()
+        }
+
+        /// Data visualization UIColor token provider
+        var datavizUIToken: DatavizUITokenProvider {
+            DatavizUITokenProvider()
+        }
+
+        /// Typography provider for this brand
+        var typography: Warp.Typography.Type {
+            Warp.Typography.self
+        }
+
+        /// Fonts for this brand
+        var fonts: [Warp.Font] {
+            Warp.Font.fonts(for: self)
+        }
+
+        /// Register fonts for this brand
+        /// - Throws: FontRegistrationError if font registration fails
+        public func registerFonts() throws {
+            try Warp.Typography.registerFonts(for: self)
+        }
     }
     
     // MARK: - Theme Property

--- a/Sources/Warp.swift
+++ b/Sources/Warp.swift
@@ -172,7 +172,6 @@ public enum Warp {
     /// It facilitates easy access to brand-specific colors that are used throughout the design system.
     ///
     /// - Warning: This uses the global `Warp.Theme` variable. Consider using `ColorProvider(theme:)` with `@Environment(\.warpTheme)` instead.
-    @available(*, deprecated, message: "Use @Environment(\\.warpTheme) and ColorProvider(theme:) instead of global Warp.Color")
     public static var Color: ColorProvider {
         ColorProvider(theme: Warp.Theme)
     }
@@ -183,7 +182,6 @@ public enum Warp {
     /// It facilitates easy access to brand-specific UIColors that are used throughout the design system.
     ///
     /// - Warning: This uses the global `Warp.Theme` variable. Consider using `UIColorProvider(theme:)` with `@Environment(\.warpTheme)` instead.
-    @available(*, deprecated, message: "Use @Environment(\\.warpTheme) and UIColorProvider(theme:) instead of global Warp.UIColor")
     public static var UIColor: UIColorProvider {
         UIColorProvider(theme: Warp.Theme)
     }

--- a/Tests/WarpTests/WarpTests.swift
+++ b/Tests/WarpTests/WarpTests.swift
@@ -81,4 +81,11 @@ struct WarpTests {
             #expect(type(of: actualUIColorProvider.token ) == type(of: expectedProvider))
         }
     }
+
+    @Test(arguments: Warp.Brand.allCases)
+    func testFontsAreRegisteredForTheme(brand: Warp.Brand) throws {
+        Warp.Theme = brand
+        let typography = Warp.Typography.self
+        try typography.registerFonts(for: brand)
+    }
 }


### PR DESCRIPTION
 ### Why
  This in future make easier to eliminate global mutable state (`Warp.Color`, `Warp.Token`) for strict concurrency compliance

  ### What
  Refactored 30+ components to use `@Environment(\.warpTheme)` instead of global singleton access:

  **Example**
  ```swift
  // Before
 Warp.Theme = .finn
SomeComponentView()

  // After
SomeComponentView()
    .warpTheme(.finn) // No global var here, propagate automatically down the view hierarchy
```