### PR TITLE
Add semantic spacing values

### DIFF
--- a/Sources/Spacing/Spacing.swift
+++ b/Sources/Spacing/Spacing.swift
@@ -6,6 +6,20 @@ extension Warp {
     /// Each spacing value corresponds to a specific amount of separation between UI elements, measured in points.
     /// These constants help maintain consistent spacing across the application.
     public enum Spacing: Sendable {
+
+        // MARK: - Semantic Values
+
+        /// Horizontal padding from the screen edges.
+        public static let screenMargin: CGFloat = spacing200
+        /// Vertical spacing at the bottom of page content, typically inside a scroll view.
+        public static let screenBottomSpacing: CGFloat = spacing200
+        /// Vertical spacing between major sections of a page.
+        public static let sectionSpacing: CGFloat = spacing300
+        /// Vertical spacing between blocks within a single section.
+        public static let sectionInnerSpacing: CGFloat = spacing200
+
+        // MARK: - Raw Values
+
         /// Separation of 2 points. Typically used for very small gaps between elements.
         public static let spacing25: CGFloat = 2
         /// Separation of 4 points. Suitable for small gaps between UI components.


### PR DESCRIPTION
# Why?

Screen level spacing isn't something we should to think about when receiving a design, it should generally stay consistent on a screen-to-screen basis.

# What?

Add semantic spacing values for a few common types of spacing. There are more, but starting small. Think of the PR as a suggestion/request.