### PR TITLE
WARP-1256 Use `borderStrong` instead of `border` in Switch

### DIFF
--- a/Sources/Components/Switch/SwitchStyle.swift
+++ b/Sources/Components/Switch/SwitchStyle.swift
@@ -64,7 +64,7 @@ extension Warp {
         private var borderColor: Color {
             switch state {
             case .default:
-                return colorProvider.token.border
+                return colorProvider.token.borderStrong
             case .disabled:
                 return colorProvider.token.borderDisabled
             }


### PR DESCRIPTION
## Why

Clearing imp. discrepancy between iOS & Web in styling tokens

## What

Use `borderStrong` token instead of `border` in Switch unselected variant.