### PR TITLE
Add heartFilled icon (filled variant of heart)

### DIFF
--- a/Sources/Icon/Icon.swift
+++ b/Sources/Icon/Icon.swift
@@ -114,6 +114,7 @@ extension Warp {
         case grill
         case headset
         case heart
+        case heartFilled
         case heartRate
         case harvester
         case hiking
@@ -439,6 +440,7 @@ extension Warp {
             case .grill: return Warp.Strings.iconGrill.localized
             case .headset: return Warp.Strings.iconHeadset.localized
             case .heart: return Warp.Strings.iconHeart.localized
+            case .heartFilled: return Warp.Strings.iconHeartFilled.localized
             case .heartRate: return Warp.Strings.iconHeartRate.localized
             case .harvester: return Warp.Strings.iconHarvester.localized
             case .hiking: return Warp.Strings.iconHiking.localized

--- a/Sources/Icon/Icons.xcassets/RegularIcons/HeartFilled.imageset/Contents.json
+++ b/Sources/Icon/Icons.xcassets/RegularIcons/HeartFilled.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "HeartFilled.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Sources/Icon/Icons.xcassets/RegularIcons/HeartFilled.imageset/HeartFilled.svg
+++ b/Sources/Icon/Icons.xcassets/RegularIcons/HeartFilled.imageset/HeartFilled.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 21S2.25 15.75 2.25 9.562A5.063 5.063 0 0 1 7.313 4.5c2.117 0 3.931 1.154 4.687 3 .756-1.846 2.57-3 4.688-3a5.062 5.062 0 0 1 5.062 5.063C21.75 15.75 12 21 12 21Z" fill="#1B1B1F" stroke="#1B1B1F" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Sources/Localized/Localized.swift
+++ b/Sources/Localized/Localized.swift
@@ -109,6 +109,7 @@ extension Warp {
         case iconGrill = "icon.title.grill"
         case iconHeadset = "icon.title.headset"
         case iconHeart = "icon.title.heart"
+        case iconHeartFilled = "icon.title.heartFilled"
         case iconHeartRate = "icon.title.heartRate"
         case iconHarvester = "icon.title.harvester"
         case iconHiking = "icon.title.hiking"


### PR DESCRIPTION
## Summary

Add a `heartFilled` Warp icon — the filled variant of the existing `heart` outline.

## Why

`Warp.Icon.heart` ships only the outline. Favorite-toggle UI universally needs both an outline (off) and a filled (on) variant. Consumers currently work around this by maintaining their own filled-heart asset or by tint-swapping the outline — neither matches the design intent. Adding `heartFilled` to Warp lets every consuming app reuse the same canonical pair.

This mirrors the existing `bell` / `bellFilled` precedent already in the icon set.

## Changes

- **`Sources/Icon/Icons.xcassets/RegularIcons/HeartFilled.imageset/`** — new vector asset.
  - `HeartFilled.svg`: the path data is **byte-for-byte identical** to `Heart.svg`; only the \`fill\` attribute differs (\`fill="#1B1B1F"\` instead of \`fill="none"\`), so the filled variant's outer silhouette matches the outline exactly when overlaid.
  - \`Contents.json\`: standard template-rendering configuration matching neighbouring icons.
- **`Sources/Icon/Icon.swift`** — new \`heartFilled\` enum case + matching arm in the \`localization\` switch, placed alphabetically between \`heart\` and \`heartRate\`.
- **`Sources/Localized/Localized.swift`** — new \`iconHeartFilled = "icon.title.heartFilled"\`.

## Test plan

- [x] Local build of consuming app (FINN iOS) succeeds with the new case usable as \`Warp.Icon.heartFilled\`.
- [ ] Run Warp's snapshot/preview suite to confirm the new icon renders at all standard sizes.
- [ ] Visual verification against the outline variant (same outer silhouette).