### PR TITLE
Do not expose `token` from `ColorProvider` struct

### DIFF
--- a/SampleApp/Components/IconView.swift
+++ b/SampleApp/Components/IconView.swift
@@ -5,7 +5,7 @@ struct IconView: View {
     @State private var selectedIcon: Warp.Icon = .activeAds // Default selected icon
     @State private var selectedSize: Warp.IconSize = .default // Default size
     @State private var customSize: Double = 50 // Default custom size for the slider
-    @State private var selectedColor: Color = Warp.Color.token.icon // Default color
+    @State private var selectedColor: Color = Warp.Token.icon // Default color
     
     private let icons = Warp.Icon.allCases // Get all icons
     private let sizes = Warp.IconSize.allCases // Add custom size option

--- a/SampleApp/Components/ShadowView.swift
+++ b/SampleApp/Components/ShadowView.swift
@@ -3,18 +3,19 @@ import SwiftUI
 
 struct ShadowView: View {
     private let colorProvider: ColorProvider = Warp.Color
+    private let tokenProvider: TokenProvider = Warp.Token
     @State private var shadow = Warp.Shadow.small
 
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
                 ZStack(alignment: .bottom) {
-                    colorProvider.token.surfaceElevated100
+                    tokenProvider.surfaceElevated100
                     Warp.Text("surfaceElevated100", style: .caption)
                         .padding(.bottom)
                 }
                 ZStack(alignment: .top) {
-                    colorProvider.token.surfaceSunken
+                    tokenProvider.surfaceSunken
                     Warp.Text("surfaceSunken", style: .caption)
                         .padding(.top)
                 }
@@ -53,7 +54,7 @@ private struct ShadowButtonStyle: ButtonStyle {
         return configuration.label
             .background {
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(Warp.Color.token.surfaceElevated200)
+                    .fill(Warp.Token.surfaceElevated200)
                     .addShadow(shadow, isPressed: configuration.isPressed)
             }
     }

--- a/SampleApp/Components/TextView.swift
+++ b/SampleApp/Components/TextView.swift
@@ -3,8 +3,8 @@ import Warp
 
 struct TextView: View {
     @State private var useGradient = false
-    @State private var firstColor = Warp.Color.token.text
-    @State private var secondColor = Warp.Color.token.textNegative
+    @State private var firstColor = Warp.Token.text
+    @State private var secondColor = Warp.Token.textNegative
 
     var body: some View {
         GroupBox {

--- a/SampleApp/ContentView.swift
+++ b/SampleApp/ContentView.swift
@@ -98,7 +98,7 @@ private struct RowView<Destination: View>: View {
         NavigationLink(destination: destination) {
             VStack(alignment: .leading) {
                 Warp.Text(title, style: .title4)
-                    .foregroundColor(ColorProvider(theme: theme).token.textLink)
+                    .foregroundColor(Warp.Token.textLink)
                     .padding()
                 Divider()
             }

--- a/Sources/Colors/ColorProvider.swift
+++ b/Sources/Colors/ColorProvider.swift
@@ -3,8 +3,8 @@ import SwiftUI
 // Generated on Wed, 04 Mar 2026 08:12:23 GMT by https://github.com/warp-ds/tokens
 // NOTE: Generator should be updated to accept theme parameter instead of using Warp.Theme global
 public struct ColorProvider {
-    public let token: TokenProvider
-    public let theme: Warp.Brand
+    let token: TokenProvider
+    let theme: Warp.Brand
 
     /// Initialize ColorProvider with a specific theme
     /// - Parameter theme: The brand theme to use
@@ -331,8 +331,8 @@ public struct ColorProvider {
 }
 
 public struct UIColorProvider {
-    public let token: UITokenProvider
-    public let theme: Warp.Brand
+    let token: UITokenProvider
+    let theme: Warp.Brand
 
     /// Initialize UIColorProvider with a specific theme
     /// - Parameter theme: The brand theme to use

--- a/Sources/Helpers/BorderOptions.swift
+++ b/Sources/Helpers/BorderOptions.swift
@@ -56,7 +56,7 @@ extension View {
     ///   - width: The thickness of the border. Defaults to `1`.
     ///   - sides: A `BorderOptions` option set specifying the sides where the border should be applied.
     /// - Returns: A view with borders on the specified sides.
-    public func border(_ color: Color = Warp.Color.token.border, width: CGFloat = 1, sides: BorderOptions) -> some View {
+    public func border(_ color: Color = Warp.Token.border, width: CGFloat = 1, sides: BorderOptions) -> some View {
         overlay(
             VStack(spacing: 0) {
                 // Add a border on the top side if specified


### PR DESCRIPTION
## Why

Now they're two ways of accessing Warp tkoens

```
Warp.Color.token.foo // or
Warp.Token.foo
```

This confuse Warp users how they should access Warp tokens

## What

Make `token` from `ColorProvider` struct internal