### PR TITLE
FEP-50 iOS: Wrong font color for navigation bar prominent color in Liquid Glass

### DIFF
--- a/Sources/Components/Native/NavigationBar/NavigationBar+Style.swift
+++ b/Sources/Components/Native/NavigationBar/NavigationBar+Style.swift
@@ -24,14 +24,12 @@ private extension UINavigationBarAppearance {
         
         let buttonAppearance = UIBarButtonItemAppearance(style: .plain)
         buttonAppearance.normal.titleTextAttributes = [
-            .foregroundColor: Warp.UIColor.token.text,
             .font: Warp.Typography.body.uiFont
         ]
         appearance.buttonAppearance = buttonAppearance
         
         let prominentButtonAppearance = UIBarButtonItemAppearance(style: .prominent)
         let prominentButtonAttributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: Warp.UIColor.token.textInverted,
             .font: Warp.Typography.title4.uiFont
         ]
         prominentButtonAppearance.normal.titleTextAttributes = prominentButtonAttributes

--- a/Sources/Components/Native/NavigationBar/UIBarButtonItem+Style.swift
+++ b/Sources/Components/Native/NavigationBar/UIBarButtonItem+Style.swift
@@ -32,22 +32,18 @@ extension UIBarButtonItem {
             self.style = .plain
             tintColor = tint
             setTitleTextAttributes([
-                .foregroundColor: Warp.UIColor.token.text,
                 .font: Warp.Typography.body.uiFont
             ], for: .normal)
             setTitleTextAttributes([
-                .foregroundColor: Warp.UIColor.token.text,
                 .font: Warp.Typography.body.uiFont
             ], for: .highlighted)
         case .primary:
             self.style = .prominent
             tintColor = primaryTint
             setTitleTextAttributes([
-                .foregroundColor: Warp.UIColor.token.text,
                 .font: Warp.Typography.title4.uiFont
             ], for: .normal)
             setTitleTextAttributes([
-                .foregroundColor: Warp.UIColor.token.text,
                 .font: Warp.Typography.title4.uiFont
             ], for: .highlighted)
         }


### PR DESCRIPTION
## Why
Liquid Glass design system handles button colors through tint colors, not explicit text color attributes. Hardcoded foregroundColor values conflict with the tint-based color application and prevent proper theming.

## What
Remove hardcoded foregroundColor attributes from navigation bar button styling:
- NavigationBar+Style.swift: Remove foregroundColor from plain and prominent button appearances
- UIBarButtonItem+Style.swift: Remove foregroundColor attributes from normal/highlighted states