### PR TITLE
Remove dead pre-iOS-18 availability checks

### DIFF
--- a/SampleApp/Components/SelectView.swift
+++ b/SampleApp/Components/SelectView.swift
@@ -37,12 +37,8 @@ struct SelectView: View {
                     helpText: helpTextValue
                 )
                 .sheet(isPresented: $presentInfoPopover) {
-                    if #available(iOS 16.0, *) {
-                        createTooltipTextView
-                            .presentationDetents([.medium, .large])
-                    } else {
-                        createTooltipTextView
-                    }
+                    createTooltipTextView
+                        .presentationDetents([.medium, .large])
                 }
             }, label: {
                 Text("Select")

--- a/SampleApp/Components/StepIndicatorView.swift
+++ b/SampleApp/Components/StepIndicatorView.swift
@@ -91,26 +91,15 @@ struct StepIndicatorView: View {
             )
 
             if let stepModel = stepModel {
-                if #available(iOS 16.0, *) {
-                    ScrollView {
-                        Warp.StepIndicator(
-                            layoutOrientation: orientation,
-                            stepModel: stepModel
-                        )
+                ScrollView {
+                    Warp.StepIndicator(
+                        layoutOrientation: orientation,
+                        stepModel: stepModel
+                    )
 
-                        Spacer()
-                    }
-                    .scrollDisabled(orientation == .horizontal)
-                } else {
-                    ScrollView {
-                        Warp.StepIndicator(
-                            layoutOrientation: orientation,
-                            stepModel: stepModel
-                        )
-
-                        Spacer()
-                    }
+                    Spacer()
                 }
+                .scrollDisabled(orientation == .horizontal)
             }
         }
         .padding()

--- a/Sources/Components/Alert/Alert.swift
+++ b/Sources/Components/Alert/Alert.swift
@@ -374,19 +374,8 @@ private struct UnderlinedLinkModifier: ViewModifier {
     }
     
     func body(content: Content) -> some View {
-        if #available(iOS 16.0, *) {
-            content
-                .underline(true, color: linkColor)
-        } else {
-            content
-                .background(lineBackground)
-        }
-    }
-    
-    private var lineBackground: some View {
-        linkColor
-            .frame(height: 1)
-            .offset(y: 8)
+        content
+            .underline(true, color: linkColor)
     }
 }
 

--- a/Sources/Components/Box/Box.swift
+++ b/Sources/Components/Box/Box.swift
@@ -274,19 +274,8 @@ private struct UnderlinedLinkModifier: ViewModifier {
     }
     
     func body(content: Content) -> some View {
-        if #available(iOS 16.0, *) {
-            content
-                .underline(true, color: linkColor)
-        } else {
-            content
-                .background(lineBackground)
-        }
-    }
-    
-    private var lineBackground: some View {
-        linkColor
-            .frame(height: 1)
-            .offset(y: 8)
+        content
+            .underline(true, color: linkColor)
     }
 }
 

--- a/Sources/Components/StepIndicator/StepIndicator.swift
+++ b/Sources/Components/StepIndicator/StepIndicator.swift
@@ -46,12 +46,8 @@ extension Warp {
         public var body: some View {
             switch layoutOrientation {
             case .horizontal:
-                if #available(iOS 16.4, *) {
-                    horizontalScrollView
-                        .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
-                } else {
-                    horizontalScrollView
-                }
+                horizontalScrollView
+                    .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
             case .vertical:
                 VStack(spacing: -1) {
                     ForEach(orderedSteps) { step in

--- a/Sources/Components/TextArea/TextArea.swift
+++ b/Sources/Components/TextArea/TextArea.swift
@@ -244,11 +244,7 @@ private struct BorderModifier: ViewModifier {
 
 private struct ClearTextEditorBackgroundModifier: ViewModifier {
     func body(content: Content) -> some View {
-        if #available(iOS 16.0, *) {
-            content.scrollContentBackground(.hidden)
-        } else {
-            content
-        }
+        content.scrollContentBackground(.hidden)
     }
 }
 

--- a/Sources/Components/TextField/TextField.swift
+++ b/Sources/Components/TextField/TextField.swift
@@ -319,11 +319,7 @@ private struct BorderModifier: ViewModifier {
 
 private struct ClearTextEditorBackgroundModifier: ViewModifier {
     func body(content: Content) -> some View {
-        if #available(iOS 16.0, *) {
-            content.scrollContentBackground(.hidden)
-        } else {
-            content
-        }
+        content.scrollContentBackground(.hidden)
     }
 }
 

--- a/Sources/Helpers/View+if.swift
+++ b/Sources/Helpers/View+if.swift
@@ -63,12 +63,8 @@ extension View {
         }
     }
 
-    /// Applies scroll bounce behavior based on content size for iOS 16.4 and above.
-    @ViewBuilder func scrollBounceBasedOnSize() -> some View {
-        if #available(iOS 16.4, *) {
-            self.scrollBounceBehavior(.basedOnSize)
-        } else {
-            self  // No-op fallback
-        }
+    /// Applies scroll bounce behavior based on content size.
+    func scrollBounceBasedOnSize() -> some View {
+        scrollBounceBehavior(.basedOnSize)
     }
 }

--- a/Sources/Patterns/StateViews/Modifiers/StateViewSheetModifier.swift
+++ b/Sources/Patterns/StateViews/Modifiers/StateViewSheetModifier.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 /// A reusable ViewModifier for presenting any StateView-based view inside a sheet.
-@available(iOS 16.0, *)
 public struct StateViewSheetModifier<StateViewContent: View>: ViewModifier {
 
     @Binding var isPresented: Bool
@@ -34,7 +33,6 @@ public struct StateViewSheetModifier<StateViewContent: View>: ViewModifier {
     }
 }
 
-@available(iOS 16.0, *)
 public extension View {
     func stateViewSheet<StateViewContent: View>(
         isPresented: Binding<Bool>,

--- a/Tests/WarpTests/SnackbarTests/SnackbarTests.swift
+++ b/Tests/WarpTests/SnackbarTests/SnackbarTests.swift
@@ -6,7 +6,6 @@ import ViewInspector
 @Suite
 struct SnackbarTests {
 
-    @available(iOS 16.0, *)
     @Test @MainActor
     func testSnackbarShouldAutomaticallyDisappear() async throws {
         let dissapearAfterTime: TimeInterval = 0.3

--- a/Tests/WarpTests/ToastTests/ToastTests.swift
+++ b/Tests/WarpTests/ToastTests/ToastTests.swift
@@ -6,7 +6,6 @@ import ViewInspector
 @Suite
 struct ToastTests {
 
-    @available(iOS 16.0, *)
     @Test @MainActor
     func testToastShouldAutomaticallyDisappear() async throws {
         let dissapearAfterTime: TimeInterval = 0.3


### PR DESCRIPTION
## Why

#230 raised the package minimum to iOS 18. Every `#available(iOS 16.x)` and `#available(iOS 17)` branch left in the codebase is now statically true, and its `else` branch is unreachable. Leaving them in place makes the code read as though it still runs somewhere below 18.

## What

Removes all 12 of them: 8 in `Sources`, 2 in `Tests`, 2 in `SampleApp`.

Behaviour is unchanged. Two helpers collapse to nothing more than the call they were guarding, and the iOS 15 fallbacks they carried go with them:

- **`UnderlinedLinkModifier`** drew a 1pt line behind link text by hand, because `.underline(_:color:)` predates iOS 16. It was duplicated verbatim in `Box.swift` and `Alert.swift`; both are now a single `.underline` call.
- **`StepIndicatorView`** in the sample app carried two copies of the same `ScrollView`, the second one existing purely to omit `.scrollDisabled`.

Also drops `@available(iOS 16.0, *)` from `StateViewSheetModifier` and its `View` extension, and from two test methods.

## Tests

**TEST SUCCEEDED** on an iOS 18.5 simulator, 57 tests in 8 suites, 0 failures. The `Finn` SampleApp scheme builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
