### PR TITLE
FEP-115 Fix GlassSegmentedControl scroll view background bleeding through

### DIFF
--- a/Sources/Components/Native/SegmentedControl/GlassSegmentedControl.swift
+++ b/Sources/Components/Native/SegmentedControl/GlassSegmentedControl.swift
@@ -55,7 +55,7 @@ extension Warp {
         sv.showsVerticalScrollIndicator = false
         sv.alwaysBounceHorizontal = true
         sv.alwaysBounceVertical = false
-        sv.backgroundColor = .clear
+        sv.backgroundColor = Warp.UIToken.background
         sv.contentInsetAdjustmentBehavior = .never
         return sv
     }()


### PR DESCRIPTION
## Why

`GlassSegmentedControl` wraps its segments in a `UIScrollView` to support horizontal scrolling when there are more segments than fit on screen. The scroll view's `backgroundColor` was set to `.clear`, which caused the segments' content to bleed through the transparent background as the user scrolled — content outside the visible bounds remained visible through the clear layer.

## What

Set `sv.backgroundColor` to `Warp.UIToken.background` instead of `.clear`.

The scroll view now paints the correct token background behind the segments, so content outside the visible clip area is hidden during scroll — matching expected behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)